### PR TITLE
File and date pickers

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
+const { dialog } = require('electron');
 const squirrel = require('electron-squirrel-startup');
 const path = require('path');
 const { logger } = require('mcode-extraction-framework');
@@ -13,12 +14,15 @@ if (squirrel) {
   app.quit();
 }
 
+// declare mainWindow ahead of time so that it can be accessed in .handle('get-file')
+let mainWindow;
 const createWindow = () => {
   // Create the browser window.
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
+      enableRemoteModule: true,
       preload: path.join(__dirname, './preload.js'),
     },
   });
@@ -65,3 +69,4 @@ ipcMain.handle('run-extraction', async (event, fromDate, toDate, configFilepath,
   const extractedData = await runExtraction(fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
   return { extractedData, loggedMessages };
 });
+ipcMain.handle('get-file', async () => dialog.showOpenDialog(mainWindow, { properties: ['openFile'] }));

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -22,7 +22,6 @@ const createWindow = () => {
     width: 800,
     height: 600,
     webPreferences: {
-      enableRemoteModule: true,
       preload: path.join(__dirname, './preload.js'),
     },
   });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -68,4 +68,9 @@ ipcMain.handle('run-extraction', async (event, fromDate, toDate, configFilepath,
   const extractedData = await runExtraction(fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
   return { extractedData, loggedMessages };
 });
-ipcMain.handle('get-file', async () => dialog.showOpenDialog(mainWindow, { properties: ['openFile'] }));
+ipcMain.handle('get-file', async () =>
+  dialog.showOpenDialog(mainWindow, {
+    filters: [{ name: 'JSON', extensions: ['json'] }],
+    properties: ['openFile'],
+  }),
+);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -17,4 +17,5 @@ contextBridge.exposeInMainWorld('api', {
     );
     return results;
   },
+  getFile: async () => ipcRenderer.invoke('get-file'),
 });

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -105,7 +105,7 @@ function Extract(props) {
                   </div>
                 </Form.Group>
                 <Form.Group controlId="formLogPath">
-                  <Form.Label className="form-label">Select Configuration File</Form.Label>
+                  <Form.Label className="form-label">Select Log File</Form.Label>
                   <div className="file-picker-box">
                     <Form.Label className="form-label file-name">{logPath}</Form.Label>
                     <div className="file-button-container">

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -20,8 +20,6 @@ function Extract(props) {
       // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
       if (promise.filePaths[0] !== undefined) {
         setConfigPath(promise.filePaths[0]);
-      } else {
-        setConfigPath('Error. Please try again');
       }
     });
   }
@@ -31,8 +29,6 @@ function Extract(props) {
       // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
       if (promise.filePaths[0] !== undefined) {
         setLogPath(promise.filePaths[0]);
-      } else {
-        setLogPath('Error. Please try again');
       }
     });
   }
@@ -62,9 +58,6 @@ function Extract(props) {
   function useSubmit() {
     setSubmitted(!submitted);
 
-    if (logPath === 'Select Log File') {
-      setLogPath('');
-    }
     // allEntries parameter is true if it's not filtered by date, false if it is
     const filter = !(filterStart || filterEnd);
     window.api.extract(fromDate, toDate, configPath, logPath, includeDebug, filter).then((value) => {

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -4,8 +4,8 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 
 function Extract(props) {
-  const [configPath, setConfigPath] = useState('Select Config File');
-  const [logPath, setLogPath] = useState('Select Log File');
+  const [configPath, setConfigPath] = useState('No File Chosen');
+  const [logPath, setLogPath] = useState('No File Chosen');
   const [includeDebug, setIncludeDebug] = useState(false);
   const [filterStart, setFilterStart] = useState(false);
   const [filterEnd, setFilterEnd] = useState(false);
@@ -24,6 +24,10 @@ function Extract(props) {
     });
   }
 
+  function deleteConfig() {
+    setConfigPath('No File Chosen');
+  }
+
   function setLog() {
     window.api.getFile().then((promise) => {
       // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
@@ -31,6 +35,10 @@ function Extract(props) {
         setLogPath(promise.filePaths[0]);
       }
     });
+  }
+
+  function deleteLog() {
+    setLogPath('No File Chosen');
   }
 
   function onIncludeDebugChange() {
@@ -75,23 +83,29 @@ function Extract(props) {
     setSubmitted(!submitted);
   }
   return (
-    <div>
+    <div className="page-container">
       <h1 className="page-title">Extract New</h1>
       {!submitted && (
-        <div>
-          <Form>
+        <div className="page-container">
+          <Form className="form-container">
             <Row>
               <Col>
                 <Form.Group controlId="formConfigPath" className="mb-3">
-                  <Form.Label className="form-label">Configuration File</Form.Label>
+                  <Form.Label className="form-label">{configPath}</Form.Label>
                   <Button className="generic-button file-picker" variant="outline-info" onClick={setConfig}>
-                    {configPath}
+                    Upload File
+                  </Button>
+                  <Button className="generic-button file-picker" variant="outline-info" onClick={deleteConfig}>
+                    Delete
                   </Button>
                 </Form.Group>
                 <Form.Group controlId="formLogPath">
-                  <Form.Label className="form-label">Previous Log File</Form.Label>
+                  <Form.Label className="form-label">{logPath}</Form.Label>
                   <Button className="generic-button file-picker" variant="outline-info" onClick={setLog}>
-                    {logPath}
+                    Upload File
+                  </Button>
+                  <Button className="generic-button file-picker" variant="outline-info" onClick={deleteLog}>
+                    Delete
                   </Button>
                 </Form.Group>
                 <Form.Group controlId="formIncludeDebug">

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -24,7 +24,7 @@ function Extract(props) {
     });
   }
 
-  function deleteConfig() {
+  function clearConfig() {
     setConfigPath('No File Chosen');
   }
 
@@ -37,7 +37,7 @@ function Extract(props) {
     });
   }
 
-  function deleteLog() {
+  function clearLog() {
     setLogPath('No File Chosen');
   }
 
@@ -95,11 +95,11 @@ function Extract(props) {
                   <div className="file-picker-box">
                     <Form.Label className="form-label file-name">{configPath}</Form.Label>
                     <div className="file-button-container">
-                      <Button className="generic-button file-picker" variant="outline-info" onClick={setConfig}>
+                      <Button className="generic-button narrow-button" variant="outline-info" onClick={setConfig}>
                         Upload File
                       </Button>
-                      <Button className="generic-button file-picker" variant="outline-info" onClick={deleteConfig}>
-                        Delete
+                      <Button className="generic-button narrow-button" variant="outline-info" onClick={clearConfig}>
+                        Clear
                       </Button>
                     </div>
                   </div>
@@ -109,11 +109,11 @@ function Extract(props) {
                   <div className="file-picker-box">
                     <Form.Label className="form-label file-name">{logPath}</Form.Label>
                     <div className="file-button-container">
-                      <Button className="generic-button file-picker" variant="outline-info" onClick={setLog}>
+                      <Button className="generic-button narrow-button" variant="outline-info" onClick={setLog}>
                         Upload File
                       </Button>
-                      <Button className="generic-button file-picker" variant="outline-info" onClick={deleteLog}>
-                        Delete
+                      <Button className="generic-button narrow-button" variant="outline-info" onClick={clearLog}>
+                        Clear
                       </Button>
                     </div>
                   </div>

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -91,22 +91,32 @@ function Extract(props) {
             <Row>
               <Col>
                 <Form.Group controlId="formConfigPath" className="mb-3">
-                  <Form.Label className="form-label">{configPath}</Form.Label>
-                  <Button className="generic-button file-picker" variant="outline-info" onClick={setConfig}>
-                    Upload File
-                  </Button>
-                  <Button className="generic-button file-picker" variant="outline-info" onClick={deleteConfig}>
-                    Delete
-                  </Button>
+                  <Form.Label className="form-label">Select Configuration File</Form.Label>
+                  <div className="file-picker-box">
+                    <Form.Label className="form-label file-name">{configPath}</Form.Label>
+                    <div className="file-button-container">
+                      <Button className="generic-button file-picker" variant="outline-info" onClick={setConfig}>
+                        Upload File
+                      </Button>
+                      <Button className="generic-button file-picker" variant="outline-info" onClick={deleteConfig}>
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
                 </Form.Group>
                 <Form.Group controlId="formLogPath">
-                  <Form.Label className="form-label">{logPath}</Form.Label>
-                  <Button className="generic-button file-picker" variant="outline-info" onClick={setLog}>
-                    Upload File
-                  </Button>
-                  <Button className="generic-button file-picker" variant="outline-info" onClick={deleteLog}>
-                    Delete
-                  </Button>
+                  <Form.Label className="form-label">Select Configuration File</Form.Label>
+                  <div className="file-picker-box">
+                    <Form.Label className="form-label file-name">{logPath}</Form.Label>
+                    <div className="file-button-container">
+                      <Button className="generic-button file-picker" variant="outline-info" onClick={setLog}>
+                        Upload File
+                      </Button>
+                      <Button className="generic-button file-picker" variant="outline-info" onClick={deleteLog}>
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
                 </Form.Group>
                 <Form.Group controlId="formIncludeDebug">
                   <Form.Check

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -1,16 +1,11 @@
 import React, { useState } from 'react';
-import path from 'path';
 import { useHistory } from 'react-router-dom';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 
 function Extract(props) {
-  const defaultPathToConfig = path.join('sample-extraction-data', 'config', 'csv.config.json');
-  // const defaultPathToRunLogs = path.join('logs', 'run-logs.json');
-  // FIXME - get rid of default config option
-
-  const [configPath, setConfigPath] = useState(defaultPathToConfig);
-  const [logPath, setLogPath] = useState('');
+  const [configPath, setConfigPath] = useState('Select Config File');
+  const [logPath, setLogPath] = useState('Select Log File');
   const [includeDebug, setIncludeDebug] = useState(false);
   const [filterStart, setFilterStart] = useState(false);
   const [filterEnd, setFilterEnd] = useState(false);
@@ -20,12 +15,26 @@ function Extract(props) {
 
   const history = useHistory();
 
-  function onConfigChange(e) {
-    setConfigPath(e.target.value);
+  function setConfig() {
+    window.api.getFile().then((promise) => {
+      // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
+      if (promise.filePaths[0] !== undefined) {
+        setConfigPath(promise.filePaths[0]);
+      } else {
+        setConfigPath('Error. Please try again');
+      }
+    });
   }
 
-  function onLogChange(e) {
-    setLogPath(e.target.value);
+  function setLog() {
+    window.api.getFile().then((promise) => {
+      // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
+      if (promise.filePaths[0] !== undefined) {
+        setLogPath(promise.filePaths[0]);
+      } else {
+        setLogPath('Error. Please try again');
+      }
+    });
   }
 
   function onIncludeDebugChange() {
@@ -76,11 +85,15 @@ function Extract(props) {
               <Col>
                 <Form.Group controlId="formConfigPath" className="mb-3">
                   <Form.Label className="form-label">Configuration File</Form.Label>
-                  <Form.Control type="text" value={configPath} onChange={onConfigChange} />
+                  <Button className="generic-button file-picker" variant="outline-info" onClick={setConfig}>
+                    {configPath}
+                  </Button>
                 </Form.Group>
                 <Form.Group controlId="formLogPath">
                   <Form.Label className="form-label">Previous Log File</Form.Label>
-                  <Form.Control type="text" value={logPath} onChange={onLogChange} />
+                  <Button className="generic-button file-picker" variant="outline-info" onClick={setLog}>
+                    {logPath}
+                  </Button>
                 </Form.Group>
                 <Form.Group controlId="formIncludeDebug">
                   <Form.Check
@@ -117,11 +130,11 @@ function Extract(props) {
           </Form>
           <div className="nav-button-container">
             <LinkContainer to="/">
-              <Button className="nav-button" size="lg" variant="outline-secondary">
+              <Button className="generic-button" size="lg" variant="outline-secondary">
                 Cancel
               </Button>
             </LinkContainer>
-            <Button className="nav-button" size="lg" variant="outline-secondary" onClick={useSubmit}>
+            <Button className="generic-button" size="lg" variant="outline-secondary" onClick={useSubmit}>
               Submit
             </Button>
           </div>
@@ -130,7 +143,7 @@ function Extract(props) {
       {submitted && (
         <div>
           <p>The form as been submitted. Running extraction...</p>
-          <Button className="nav-button" size="lg" variant="outline-secondary" onClick={onReset}>
+          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onReset}>
             Reset
           </Button>
         </div>

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -93,7 +93,6 @@ function Extract(props) {
                 <Form.Group controlId="formConfigPath" className="mb-3">
                   <Form.Label className="form-label">Select Configuration File</Form.Label>
                   <div className="file-picker-box">
-                    <Form.Label className="form-label file-name">{configPath}</Form.Label>
                     <div className="file-button-container">
                       <Button className="generic-button narrow-button" variant="outline-info" onClick={setConfig}>
                         Upload File
@@ -102,12 +101,12 @@ function Extract(props) {
                         Clear
                       </Button>
                     </div>
+                    <Form.Label className="form-label file-name">{configPath}</Form.Label>
                   </div>
                 </Form.Group>
                 <Form.Group controlId="formLogPath">
                   <Form.Label className="form-label">Select Log File</Form.Label>
                   <div className="file-picker-box">
-                    <Form.Label className="form-label file-name">{logPath}</Form.Label>
                     <div className="file-button-container">
                       <Button className="generic-button narrow-button" variant="outline-info" onClick={setLog}>
                         Upload File
@@ -116,6 +115,7 @@ function Extract(props) {
                         Clear
                       </Button>
                     </div>
+                    <Form.Label className="form-label file-name">{logPath}</Form.Label>
                   </div>
                 </Form.Group>
                 <Form.Group controlId="formIncludeDebug">

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -9,8 +9,8 @@ function Extract(props) {
   const [includeDebug, setIncludeDebug] = useState(false);
   const [filterStart, setFilterStart] = useState(false);
   const [filterEnd, setFilterEnd] = useState(false);
-  const [fromDate] = useState('');
-  const [toDate] = useState('');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
   const [submitted, setSubmitted] = useState(false);
 
   const history = useHistory();
@@ -43,22 +43,28 @@ function Extract(props) {
 
   function onFilterStartChange() {
     setFilterStart(!filterStart);
+    setFromDate('');
   }
 
   function onFilterEndChange() {
     setFilterEnd(!filterEnd);
+    setToDate('');
   }
 
-  // function onFromDateChange(e) {
-  //     setFromDate(e.target.value);
-  // }
+  function onFromDateChange(e) {
+    setFromDate(e.target.value);
+  }
 
-  // function onToDateChange(e) {
-  //     setToDate(e.target.value);
-  // }
+  function onToDateChange(e) {
+    setToDate(e.target.value);
+  }
 
   function useSubmit() {
     setSubmitted(!submitted);
+
+    if (logPath === 'Select Log File') {
+      setLogPath('');
+    }
     // allEntries parameter is true if it's not filtered by date, false if it is
     const filter = !(filterStart || filterEnd);
     window.api.extract(fromDate, toDate, configPath, logPath, includeDebug, filter).then((value) => {
@@ -115,6 +121,11 @@ function Extract(props) {
                     onChange={onFilterStartChange}
                   />
                 </Form.Group>
+                {filterStart && (
+                  <Form.Group controlId="formStartDate">
+                    <Form.Control type="date" label="Start Date" onChange={onFromDateChange} value={fromDate} />
+                  </Form.Group>
+                )}
               </Col>
               <Col>
                 <Form.Group controlId="formIncludeEndDate">
@@ -125,6 +136,11 @@ function Extract(props) {
                     onChange={onFilterEndChange}
                   />
                 </Form.Group>
+                {filterEnd && (
+                  <Form.Group controlId="formEndDate">
+                    <Form.Control type="date" label="End Date" onChange={onToDateChange} value={toDate} />
+                  </Form.Group>
+                )}
               </Col>
             </Row>
           </Form>

--- a/react-app/src/components/ExtractionError.js
+++ b/react-app/src/components/ExtractionError.js
@@ -13,7 +13,7 @@ function ExtractionError(props) {
       </p>
       <div className="button-container">
         <LinkContainer to="/extract">
-          <Button className="nav-button" size="lg" variant="outline-secondary">
+          <Button className="generic-button" size="lg" variant="outline-secondary">
             Extract New
           </Button>
         </LinkContainer>

--- a/react-app/src/components/PatientData.js
+++ b/react-app/src/components/PatientData.js
@@ -18,7 +18,7 @@ function PatientData(props) {
       )}
       {props.id !== null && !props.showLogs && (
         <div className="patient-json-display">
-          <ReactJson src={props.patientJson} collapsed={3} />
+          <ReactJson src={props.patientJson} collapsed={4} />
         </div>
       )}
     </div>

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -38,10 +38,10 @@ function ResultSidebar(props) {
         </Accordion>
       </div>
       <div className="nav-button-container">
-        <Button className="nav-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
+        <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
           Exit
         </Button>
-        <Button className="nav-button" siz="lg" variant="outline-secondary" onClick={onSave}>
+        <Button className="generic-button" siz="lg" variant="outline-secondary" onClick={onSave}>
           Save
         </Button>
       </div>

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -1,4 +1,18 @@
 @import './_variables.scss';
+
+.page-container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 100vh;
+  justify-content: space-between;
+}
+
+.form-container {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 .page-background {
   background-color: $light-shade;
   background-size: cover;

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -78,11 +78,6 @@
   margin-top: 20px;
 }
 
-.file-picker {
-  font-size: 14px;
-  margin-left: 20px;
-}
-
 .nav-button-container {
   display: flex;
   justify-content: space-between;
@@ -94,4 +89,28 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+.file-picker-box {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  vertical-align: center;
+}
+
+.file-button-container {
+  display: flex;
+  justify-content: space-betweeen;
+}
+
+.file-picker {
+  font-size: 14px;
+  margin-bottom: 0px;
+  margin-left: 20px;
+  margin-top: 0px;
+}
+
+.file-name {
+  color: $secondary;
+  font-weight: bold;
 }

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -103,7 +103,7 @@
   justify-content: space-betweeen;
 }
 
-.file-picker {
+.narrow-button {
   font-size: 14px;
   margin-bottom: 0px;
   margin-left: 20px;

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -57,11 +57,16 @@
   padding-top: 100px;
 }
 
-.nav-button {
+.generic-button {
   font-family: 'Courier New', 'Monaco', monospace;
   font-size: 18px;
   margin-bottom: 20px;
   margin-top: 20px;
+}
+
+.file-picker {
+  font-size: 14px;
+  margin-left: 20px;
 }
 
 .nav-button-container {

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -95,6 +95,7 @@
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
+  margin-bottom: 20px;
   vertical-align: center;
 }
 
@@ -106,7 +107,7 @@
 .narrow-button {
   font-size: 14px;
   margin-bottom: 0px;
-  margin-left: 20px;
+  margin-right: 20px;
   margin-top: 0px;
 }
 

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -33,6 +33,7 @@
   color: $primary;
   font-family: 'Courier New', 'Monaco', monospace;
   font-size: 60px;
+  text-align: center;
 }
 
 .page-text {


### PR DESCRIPTION
### Summary
The form on the Extract page was modified. The config file path and log file path fields now have file selectors instead of text inputs. When the user checks "Filter by start date" or "Filter by end date", a date picker appears under the checkbox, allowing the user to chose to and from dates.

### Code Changes
The form on the Extract page was modified to use file and date pickers, and to update the toDate and fromDate variables based on input. preload.js and electron.js were modified to add functions to handle file selection.

### New Behavior
The user selects config and log files using a file picker. The user is able to filter results by date.

### Testing Guidance
Start the app with npm start. Click on "Extract New". Click on "Select Config File" or "Select Log File" to open the file selectors and choose files. Check "Filter by start date" to make the date picker for fromDate appear. Check "Filter by end date" to make the date picker for fromDate appear. Any combination of values (dates, log file, etc) that would work for the command line interface should also work in the UI.
