### PR TITLE
Logger statistics

### DIFF
--- a/electron/InMemoryTransport.js
+++ b/electron/InMemoryTransport.js
@@ -11,7 +11,9 @@ module.exports = class InMemoryTransport extends Transport {
     const MESSAGE_SYMBOL = Symbol.for('message');
     const message = info[MESSAGE_SYMBOL];
     const strippedMessage = stripAnsi(message);
-    this.loggedMessages.push(strippedMessage);
+    console.log('info: ', info);
+    console.log('level: ', stripAnsi(info.level));
+    this.loggedMessages.push({ message: strippedMessage, level: stripAnsi(info.level) });
     // Perform the writing to the remote service
     callback();
   }

--- a/electron/InMemoryTransport.js
+++ b/electron/InMemoryTransport.js
@@ -11,8 +11,6 @@ module.exports = class InMemoryTransport extends Transport {
     const MESSAGE_SYMBOL = Symbol.for('message');
     const message = info[MESSAGE_SYMBOL];
     const strippedMessage = stripAnsi(message);
-    console.log('info: ', info);
-    console.log('level: ', stripAnsi(info.level));
     this.loggedMessages.push({ message: strippedMessage, level: stripAnsi(info.level) });
     // Perform the writing to the remote service
     callback();

--- a/react-app/src/components/LogList.js
+++ b/react-app/src/components/LogList.js
@@ -4,9 +4,9 @@ import { ListGroup } from 'react-bootstrap';
 import '../stylesheets/LogList.scss';
 
 function LogList(props) {
-  const list = props.loggedMessages.map((message, i) => (
+  const list = props.loggedMessages.map((log, i) => (
     <ListGroup.Item className="log-message" key={i}>
-      {message}
+      {log.message}
     </ListGroup.Item>
   ));
   return <ListGroup className={props.listType}>{list}</ListGroup>;

--- a/react-app/src/components/ResultPage.js
+++ b/react-app/src/components/ResultPage.js
@@ -15,7 +15,12 @@ function ResultPage(props) {
       <Container fluid>
         <Row>
           <Col xxl={3} xl={3} lg={3} md={3} sm={3} xs={3} className="sidebar-col">
-            <ResultSidebar extractedData={props.extractedData} setPatientID={setPatientID} setShowLogs={setShowLogs} />
+            <ResultSidebar
+              extractedData={props.extractedData}
+              loggedMessages={props.loggedMessages}
+              setPatientID={setPatientID}
+              setShowLogs={setShowLogs}
+            />
           </Col>
           <Col>
             <PatientData

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -15,6 +15,37 @@ function ResultSidebar(props) {
     // Save the results permanently somehow
   }
 
+  function getLoggerStats() {
+    let errors = 0;
+    let warnings = 0;
+    let debugs = 0;
+    let total = 0;
+
+    props.loggedMessages.forEach((log) => {
+      if (log.level === 'error') {
+        errors += 1;
+      }
+      if (log.level === 'warn') {
+        warnings += 1;
+      }
+      if (log.level === 'debug') {
+        debugs += 1;
+      }
+      total += 1;
+    });
+
+    return (
+      <Accordion.Body>
+        <p key={0}>Errors: {errors}</p>
+        <p key={1}>Warnings: {warnings}</p>
+        <p key={2}>Debug Messages: {debugs}</p>
+        <p className="emphasized-list-text" key={3}>
+          Total Messages: {total}
+        </p>
+      </Accordion.Body>
+    );
+  }
+
   const list = props.extractedData.map((bundle, i) => (
     <Result bundle={bundle} id={i} setPatientID={props.setPatientID} key={i} setShowLogs={props.setShowLogs} />
   ));
@@ -33,6 +64,7 @@ function ResultSidebar(props) {
             >
               Log File
             </Accordion.Header>
+            {getLoggerStats()}
           </Accordion.Item>
           {list}
         </Accordion>

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -18,7 +18,6 @@ function ResultSidebar(props) {
   function getLoggerStats() {
     let errors = 0;
     let warnings = 0;
-    let total = 0;
 
     props.loggedMessages.forEach((log) => {
       if (log.level === 'error') {
@@ -27,12 +26,10 @@ function ResultSidebar(props) {
       if (log.level === 'warn') {
         warnings += 1;
       }
-      total += 1;
     });
 
     return (
       <Accordion.Body>
-        <p className="emphasized-list-text">Total Messages: {total}</p>
         <p>Errors: {errors}</p>
         <p>Warnings: {warnings}</p>
       </Accordion.Body>

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -18,7 +18,6 @@ function ResultSidebar(props) {
   function getLoggerStats() {
     let errors = 0;
     let warnings = 0;
-    let debugs = 0;
     let total = 0;
 
     props.loggedMessages.forEach((log) => {
@@ -28,20 +27,14 @@ function ResultSidebar(props) {
       if (log.level === 'warn') {
         warnings += 1;
       }
-      if (log.level === 'debug') {
-        debugs += 1;
-      }
       total += 1;
     });
 
     return (
       <Accordion.Body>
-        <p key={0}>Errors: {errors}</p>
-        <p key={1}>Warnings: {warnings}</p>
-        <p key={2}>Debug Messages: {debugs}</p>
-        <p className="emphasized-list-text" key={3}>
-          Total Messages: {total}
-        </p>
+        <p className="emphasized-list-text">Total Messages: {total}</p>
+        <p>Errors: {errors}</p>
+        <p>Warnings: {warnings}</p>
       </Accordion.Body>
     );
   }

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -33,7 +33,6 @@
   color: $primary;
   font-family: 'Courier New', 'Monaco', monospace;
   font-size: 60px;
-  text-align: center;
 }
 
 .page-text {


### PR DESCRIPTION
Summary
Logger statistics display in the "Log File" dropdown in the sidebar of the result page.

Code Changes
- Changed return value of InMemoryTransport
- Changed LogList to account for new return value
- Modified sidebar to calculate number of errors, warnings, debug messages, and total messages

New Behavior
When you click on the Log File dropdown in the sidebar of the result page, the number of each type of message (excluding info-level messages) will appear in a list.

Testing Guidance
Run the app with npm start. Run extraction with any input that doesn't cause fatal errors. Click on "Log File" in the sidebar. The message counts will appear underneath.
