### PR TITLE
Save output

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -77,6 +77,7 @@ ipcMain.handle('get-file', async () =>
 
 ipcMain.handle('get-output-path', async () => {
   const options = {
+    buttonLabel: 'Save',
     title: 'Select Output Folder',
     defaultPath: app.getPath('downloads'),
     properties: ['openDirectory', 'createDirectory'],

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -85,8 +85,14 @@ ipcMain.handle('get-output-path', async () => {
 });
 
 ipcMain.handle('save-output', async (event, savePath, extractedData) => {
-  extractedData.forEach((bundle, i) => {
-    const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
-    fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
-  });
+  try {
+    extractedData.forEach((bundle, i) => {
+      const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
+      fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
+      // 'false' as in 'no error'
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
 });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -90,8 +90,10 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
       const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
       fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
     });
+    // retuerning true indicates that the save process succeeded
     return true;
   } catch (error) {
+    // returning false indicates that something went wrong during the save process
     return false;
   }
 });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -89,7 +89,6 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
     extractedData.forEach((bundle, i) => {
       const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
       fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
-      // 'false' as in 'no error'
     });
     return true;
   } catch (error) {

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -93,7 +93,7 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
     // retuerning true indicates that the save process succeeded
     return true;
   } catch (error) {
-    // returning false indicates that something went wrong during the save process
-    return false;
+    // return the error message
+    return error.message;
   }
 });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -1,6 +1,6 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
-const { dialog } = require('electron');
+const { app, BrowserWindow, dialog, ipcMain } = require('electron');
 const squirrel = require('electron-squirrel-startup');
+const fs = require('fs');
 const path = require('path');
 const { logger } = require('mcode-extraction-framework');
 const runExtraction = require('./extraction');
@@ -74,3 +74,19 @@ ipcMain.handle('get-file', async () =>
     properties: ['openFile'],
   }),
 );
+
+ipcMain.handle('get-output-path', async () => {
+  const options = {
+    title: 'Select Output Folder',
+    defaultPath: app.getPath('downloads'),
+    properties: ['openDirectory', 'createDirectory'],
+  };
+  return dialog.showOpenDialog(null, options, (savePath) => savePath);
+});
+
+ipcMain.handle('save-output', async (event, savePath, extractedData) => {
+  extractedData.forEach((bundle, i) => {
+    const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
+    fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
+  });
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -23,6 +23,7 @@ contextBridge.exposeInMainWorld('api', {
     return savePath;
   },
   saveOutput: async (savePath, extractedData) => {
-    await ipcRenderer.invoke('save-output', savePath, extractedData);
+    const result = await ipcRenderer.invoke('save-output', savePath, extractedData);
+    return result;
   },
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -18,4 +18,11 @@ contextBridge.exposeInMainWorld('api', {
     return results;
   },
   getFile: async () => ipcRenderer.invoke('get-file'),
+  getOutputPath: async () => {
+    const savePath = await ipcRenderer.invoke('get-output-path');
+    return savePath;
+  },
+  saveOutput: async (savePath, extractedData) => {
+    await ipcRenderer.invoke('save-output', savePath, extractedData);
+  },
 });

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -42,6 +42,12 @@ function ResultSidebar(props) {
             setShowErrorAlert(true);
           }
           // If result is null, the process was cancelled, and nothing should be done.
+        })
+        .catch((error) => {
+          setShowErrorAlert(true);
+          setErrorMessage(error.message);
+          setShowSavedAlert(false);
+          setShowNoFilesAlert(false);
         });
     } else {
       setShowNoFilesAlert(true);

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -16,11 +16,13 @@ function ResultSidebar(props) {
 
   function onSave() {
     window.api.getOutputPath().then((savePath) => {
-      const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
-      if (result) {
-        setShowSavedAlert(true);
-      } else {
-        setShowErrorAlert(true);
+      if (!savePath.canceled) {
+        const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+        if (result) {
+          setShowSavedAlert(true);
+        } else {
+          setShowErrorAlert(true);
+        }
       }
     });
   }

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -8,6 +8,7 @@ function ResultSidebar(props) {
   const history = useHistory();
   const [showSavedAlert, setShowSavedAlert] = useState(false);
   const [showErrorAlert, setShowErrorAlert] = useState(false);
+  const [showNoFilesAlert, setShowNoFilesAlert] = useState(false);
 
   function onExitResultPage() {
     // reset data values and return to home page
@@ -15,16 +16,20 @@ function ResultSidebar(props) {
   }
 
   function onSave() {
-    window.api.getOutputPath().then((savePath) => {
-      if (!savePath.canceled) {
-        const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
-        if (result) {
-          setShowSavedAlert(true);
-        } else {
-          setShowErrorAlert(true);
+    if (props.extractedData.length > 0) {
+      window.api.getOutputPath().then((savePath) => {
+        if (!savePath.canceled) {
+          const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+          if (result) {
+            setShowSavedAlert(true);
+          } else {
+            setShowErrorAlert(true);
+          }
         }
-      }
-    });
+      });
+    } else {
+      setShowNoFilesAlert(true);
+    }
   }
 
   function getLoggerStats() {
@@ -73,7 +78,7 @@ function ResultSidebar(props) {
       </div>
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
-          <Alert.Heading>Files Saved</Alert.Heading>
+          <Alert.Heading>Files saved</Alert.Heading>
         </Alert>
       )}
       {showErrorAlert && (
@@ -81,7 +86,12 @@ function ResultSidebar(props) {
           <Alert.Heading>Error: Unable to save file(s)</Alert.Heading>
         </Alert>
       )}
-      {!showSavedAlert && !showErrorAlert && (
+      {showNoFilesAlert && (
+        <Alert variant="warning" show={showNoFilesAlert} onClose={() => setShowNoFilesAlert(false)} dismissible>
+          <Alert.Heading>Error: No patient data to save</Alert.Heading>
+        </Alert>
+      )}
+      {!showSavedAlert && !showErrorAlert && !showNoFilesAlert && (
         <div className="sidebar-button-container">
           <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
             Exit

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -17,16 +17,29 @@ function ResultSidebar(props) {
 
   function onSave() {
     if (props.extractedData.length > 0) {
-      window.api.getOutputPath().then((savePath) => {
-        if (!savePath.canceled) {
-          const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+      window.api
+        .getOutputPath()
+        .then((savePath) => {
+          if (!savePath.canceled) {
+            return savePath;
+          }
+          return null;
+        })
+        .then((savePath) => {
+          if (savePath) {
+            return window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+          }
+          return null;
+        })
+        .then((result) => {
           if (result) {
+            // if saveOutput() returns true, then the save process succeeded
             setShowSavedAlert(true);
-          } else {
+          } else if (result !== null) {
+            // if saveOutput() returns false, then the save process succeeded. If result is null, the process was cancelled, and nothing should be done.
             setShowErrorAlert(true);
           }
-        }
-      });
+        });
     } else {
       setShowNoFilesAlert(true);
     }

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -8,6 +8,7 @@ function ResultSidebar(props) {
   const history = useHistory();
   const [showSavedAlert, setShowSavedAlert] = useState(false);
   const [showErrorAlert, setShowErrorAlert] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const [showNoFilesAlert, setShowNoFilesAlert] = useState(false);
 
   function onExitResultPage() {
@@ -32,13 +33,15 @@ function ResultSidebar(props) {
           return null;
         })
         .then((result) => {
-          if (result) {
+          if (result === true) {
             // if saveOutput() returns true, then the save process succeeded
             setShowSavedAlert(true);
-          } else if (result !== null) {
-            // if saveOutput() returns false, then the save process succeeded. If result is null, the process was cancelled, and nothing should be done.
+          } else if (typeof result === 'string') {
+            // if the result is a string, that means the save process returned an error message
+            setErrorMessage(result);
             setShowErrorAlert(true);
           }
+          // If result is null, the process was cancelled, and nothing should be done.
         });
     } else {
       setShowNoFilesAlert(true);
@@ -97,6 +100,7 @@ function ResultSidebar(props) {
       {showErrorAlert && (
         <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
           <Alert.Heading>Error: Unable to save file(s)</Alert.Heading>
+          <p>{errorMessage}</p>
         </Alert>
       )}
       {showNoFilesAlert && (

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -7,6 +7,8 @@ import Result from './Result';
 function ResultSidebar(props) {
   const history = useHistory();
   const [showSavedAlert, setShowSavedAlert] = useState(false);
+  const [showErrorAlert, setShowErrorAlert] = useState(false);
+
   function onExitResultPage() {
     // reset data values and return to home page
     history.push('/extract');
@@ -14,8 +16,12 @@ function ResultSidebar(props) {
 
   function onSave() {
     window.api.getOutputPath().then((savePath) => {
-      window.api.saveOutput(savePath.filePaths[0], props.extractedData);
-      setShowSavedAlert(true);
+      const result = window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+      if (result) {
+        setShowSavedAlert(true);
+      } else {
+        setShowErrorAlert(true);
+      }
     });
   }
 
@@ -63,17 +69,26 @@ function ResultSidebar(props) {
           {list}
         </Accordion>
       </div>
-      <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
-        <Alert.Heading>Files Saved</Alert.Heading>
-      </Alert>
-      <div className="sidebar-button-container">
-        <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
-          Exit
-        </Button>
-        <Button className="generic-button" siz="lg" variant="outline-secondary" onClick={onSave}>
-          Save
-        </Button>
-      </div>
+      {showSavedAlert && (
+        <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
+          <Alert.Heading>Files Saved</Alert.Heading>
+        </Alert>
+      )}
+      {showErrorAlert && (
+        <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
+          <Alert.Heading>Error: Unable to save file(s)</Alert.Heading>
+        </Alert>
+      )}
+      {!showSavedAlert && !showErrorAlert && (
+        <div className="sidebar-button-container">
+          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
+            Exit
+          </Button>
+          <Button className="generic-button" siz="lg" variant="outline-secondary" onClick={onSave}>
+            Save
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -1,18 +1,22 @@
-import React from 'react';
-import { Button, Accordion } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Alert, Button, Accordion } from 'react-bootstrap';
 import { useHistory } from 'react-router-dom';
 import ResultHeader from './ResultHeader';
 import Result from './Result';
 
 function ResultSidebar(props) {
   const history = useHistory();
+  const [showSavedAlert, setShowSavedAlert] = useState(false);
   function onExitResultPage() {
     // reset data values and return to home page
     history.push('/extract');
   }
 
   function onSave() {
-    // Save the results permanently somehow
+    window.api.getOutputPath().then((savePath) => {
+      window.api.saveOutput(savePath.filePaths[0], props.extractedData);
+      setShowSavedAlert(true);
+    });
   }
 
   function getLoggerStats() {
@@ -59,6 +63,9 @@ function ResultSidebar(props) {
           {list}
         </Accordion>
       </div>
+      <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
+        <Alert.Heading>Files Saved</Alert.Heading>
+      </Alert>
       <div className="sidebar-button-container">
         <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
           Exit


### PR DESCRIPTION
### Summary
Users can save the patient JSON schemas to a folder on their computer.

### New Behavior
When the user clicks the "Save" button on the output page, a file explorer opens up, allowing them to select a folder to download the patient JSON schemas to. The page will display a success alert if saving succeeded, and an error alert if fs.writeFileSync() throws an error.

### Code Changes
- Functions added to preload.js and electron.js to handle the backend of opening the file explorer and writing files
- onSave() function now has code in it
- Alerts that display when after the user saves (or fails to save) info

### Testing Guidance
Start the app with npm start. Click "Extract New". Run extraction with any set of data that will not lead to fatal errors. Click "Save" and choose a folder. 
- If there is patient data to save, it will save, and an alert will appear informing you that it has saved. Click the "x" to dismiss the alert.
- If saving fails, an error alert will appear. Click the "x" to dismiss it.
- If you cancel without choosing a folder, there will be no alert.
- If you try to save when there's no patient data (reload the window to remove patient data), a warning will appear informing you that there's nothing to save. Click the "x" to dismiss it.
