### PR TITLE
Added condition to handle extraction errors

### DIFF
--- a/electron/extraction.js
+++ b/electron/extraction.js
@@ -22,7 +22,7 @@ async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, d
       runLogFilepath,
       defaultDebug,
       allEntries,
-    ).then((value) => value);
+    );
 
     if (!extractedData) {
       return null;

--- a/electron/extraction.js
+++ b/electron/extraction.js
@@ -23,6 +23,10 @@ async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, d
       defaultDebug,
       allEntries,
     ).then((value) => value);
+
+    if (!extractedData) {
+      return null;
+    }
     return extractedData;
   } catch (e) {
     if (debug) logger.level = 'debug';


### PR DESCRIPTION
### Summary
In the past, a bug occasionally occurred where extractedData would be undefined, causing the app to crash instead of going to the error page. While I wasn't able to trigger the bug, I did identify where it might come from. The runExtraction() function in extraction.js previously returned one of two things:

- extractedData, if the call to mcodeApp() didn't throw an error
- null, if the call to mcodeApp() threw an error

The front-end extraction code in Extract.js then checks the return value to decide where to redirect:
```
if (value.extractedData === null) {
  history.push('/extraction-error');
} else {
  history.push('/results');
}
```
If mcodeApp() failed and returned undefined without throwing an error, this could cause the UI to crash.

### New Behavior
The try block in the runExtraction() function now checks the value of extractedData to make sure that it exists. If it doesn't, the function returns null: 
```
if (!extractedData) {
      return null;
}
return extractedData;
```
### Code Changes
The above if statement was added to runExtraction() in extraction.js.

### Attempts to Find the Bug
In order to trigger the bug, I tried:
- Cloning a new version of the repositry
- Running the app without running npm install in either the electron or React apps. The app didn't start at all, so this didn't cause the bug.
- Running the app after running npm install in the electron app, but not in the React app. This also prevented the app from starting at all, so it didn't cause the bug.
- Deleting characters / adding letters to / etc. the config file path in Extract form. Having a nonexistent / invalid config file didn't trigger the bug.
- Using a nonexistent .docx file as the config file
- Using a real .docx file as the config file
- Adding typos to, deleting things from, and messing with the format of the config file
- Having invalid extractor file paths in the config file
- Adding typos to, deleting things from, and messing with the format of the CSV files
All of these input redirected to the error page, as expected. The bug did not appear.