### PR TITLE
Make sidebar scroll when larger than window

### DIFF
--- a/react-app/src/components/ResultSidebar.js
+++ b/react-app/src/components/ResultSidebar.js
@@ -59,7 +59,7 @@ function ResultSidebar(props) {
           {list}
         </Accordion>
       </div>
-      <div className="nav-button-container">
+      <div className="sidebar-button-container">
         <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onExitResultPage}>
           Exit
         </Button>

--- a/react-app/src/stylesheets/ResultPage.scss
+++ b/react-app/src/stylesheets/ResultPage.scss
@@ -26,6 +26,15 @@
   flex-direction: column;
   justify-content: flex-start;
   height: 100vh;
+  overflow-y: scroll;
+  padding-right: 0px;
+}
+
+.sidebar-button-container {
+  display: flex;
+  justify-content: space-between;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .patient-json-display {


### PR DESCRIPTION
### Summary
Previously, when the sidebar was longer than the window, part of it would get cut off and would be inaccessible. Now the sidebar has a scrollbar.

### New Behavior
When the sidebar is longer than the window, it scrolls instead of having part of it cut off. Additionally, the Exit and Save buttons are sticky, so they are always visible.

### Code Changes

- Modified CSS class for the sidebar-interior. 
- Created a new sidebar-button-container class, since nav-button-container didn't look right with the scrolling.

### Testing Guidance
Use npm start to start the app. Click on "Extract New". Run extraction with any data that will not cause a fatal extraction error. Click on one of the drop-downs in the accordion to make it expand. If necessary, change the window size to make it shorter than the sidebar. A scrollbar will appear. You can now scroll the accordion up and down.