### PR TITLE
Patient result label

### DIFF
--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -43,36 +43,27 @@ function Result(props) {
       const mrn = patient.id;
       const name = patient.name[0].text;
 
-      let isMasked = fhirpath.evaluate(patient, 'Patient.identifier.extension.valueCode')[0];
-
-      if (isMasked === 'masked') {
-        isMasked = true;
-      } else {
-        isMasked = false;
-      }
+      const isMasked = fhirpath.evaluate(patient, 'Patient.identifier.extension.valueCode')[0] === 'masked';
 
       // if both MRN and name -- return string w / both
       if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0 && !isMasked) {
         const label = mrn.concat(': ').concat(name);
         return <p className="accordion-result-label">{label}</p>;
       }
+      // if either MRN or name -- return string / the available one
       if (typeof name === 'string' && name.length > 0) {
         return <p className="accordion-result-label">{name}</p>;
       }
+      // if neither MRN nor name -- "Patient " + patient_resource_id
       if (typeof mrn === 'string' && mrn.length > 0) {
         return <p className="accordion-result-label">{mrn}</p>;
       }
     }
 
+    // if no patient resource ID -- return "Patient " + props.id
     let label = 'Patient';
     label = label.concat(' ').concat(props.id.toString());
     return <p className="accordion-result-label">{label}</p>;
-
-    // if either MRN or name -- return string / the available one
-
-    // if neither MRN nor name -- "Patient " + patient_resource_id
-
-    // if no patient resource ID -- return "Patient " + props.id
   }
 
   const resourceList = countResources();

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -36,6 +36,20 @@ function Result(props) {
     return total;
   }
 
+  function getLabel() {
+    // attempt to get MRN and name with fhirpath
+    const mrnPath = 'Bundle.descendants().resource.resourceType';
+    const namePath = 'Bundle.descendants().resource.resourceType';
+
+    // if both MRN and name -- return string w / both
+
+    // if either MRN or name -- return string / the available one
+
+    // if neither MRN nor name -- "Patient " + patient_resource_id
+
+    // if no patient resource ID -- return "Patient " + props.id
+  }
+
   const resourceList = countResources();
 
   return (

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -51,20 +51,20 @@ function Result(props) {
     // if both MRN and name -- return string w / both
     if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0) {
       const label = mrn.concat(': ').concat(name);
-      return label;
+      return <p className="accordion-result-label">{label}</p>;
     }
     if (typeof mrn === 'string' && mrn.length > 0) {
-      return mrn;
+      return <p className="accordion-result-label">{mrn}</p>;
     }
     if (typeof name === 'string' && name.length > 0) {
-      return name;
+      return <p className="accordion-result-label">{name}</p>;
     }
     if (typeof resourceID === 'string' && resourceID.length > 0) {
-      return resourceID;
+      return <p className="accordion-result-label">{resourceID}</p>;
     }
     let label = 'Patient';
     label = label.concat(' ').concat(props.id.toString());
-    return label;
+    return <p className="accordion-result-label">{label}</p>;
 
     // if either MRN or name -- return string / the available one
 
@@ -78,7 +78,6 @@ function Result(props) {
   return (
     <Accordion.Item eventKey={props.id}>
       <Accordion.Header
-        className="result-label"
         onClick={() => {
           props.setPatientID(props.id);
           props.setShowLogs(false);

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -38,10 +38,33 @@ function Result(props) {
 
   function getLabel() {
     // attempt to get MRN and name with fhirpath
-    const mrnPath = 'Bundle.descendants().resource.resourceType';
-    const namePath = 'Bundle.descendants().resource.resourceType';
+    const mrn = fhirpath.evaluate(props.bundle, "Bundle.descendants().resource.where(resourceType='Patient').id")[0];
+    const name = fhirpath.evaluate(
+      props.bundle,
+      "Bundle.descendants().resource.where(resourceType='Patient').name.text",
+    )[0];
+    const resourceID = fhirpath.evaluate(
+      props.bundle,
+      "Bundle.descendants().where(resource.resourceType='Patient').fullUrl",
+    )[0];
 
     // if both MRN and name -- return string w / both
+    if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0) {
+      const label = mrn.concat(': ').concat(name);
+      return label;
+    }
+    if (typeof mrn === 'string' && mrn.length > 0) {
+      return mrn;
+    }
+    if (typeof name === 'string' && name.length > 0) {
+      return name;
+    }
+    if (typeof resourceID === 'string' && resourceID.length > 0) {
+      return resourceID;
+    }
+    let label = 'Patient';
+    label = label.concat(' ').concat(props.id.toString());
+    return label;
 
     // if either MRN or name -- return string / the available one
 
@@ -55,12 +78,13 @@ function Result(props) {
   return (
     <Accordion.Item eventKey={props.id}>
       <Accordion.Header
+        className="result-label"
         onClick={() => {
           props.setPatientID(props.id);
           props.setShowLogs(false);
         }}
       >
-        Patient {props.id}
+        {getLabel()}
       </Accordion.Header>
       <Accordion.Body>
         <p className="emphasized-list-text">Total Resources: {getNumResources(resourceList)}</p>

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -38,33 +38,30 @@ function Result(props) {
 
   function getLabel() {
     // attempt to get MRN and name with fhirpath
-    const mrn = fhirpath.evaluate(props.bundle, "Bundle.descendants().resource.where(resourceType='Patient').id")[0];
-    const name = fhirpath.evaluate(
-      props.bundle,
-      "Bundle.descendants().resource.where(resourceType='Patient').name.text",
-    )[0];
+    const patient = fhirpath.evaluate(props.bundle, "Bundle.descendants().resource.where(resourceType='Patient')")[0];
+    if (patient) {
+      const mrn = patient.id;
+      const name = patient.name[0].text;
 
-    let isMasked = fhirpath.evaluate(
-      props.bundle,
-      "Bundle.descendants().resource.where(resourceType='Patient').identifier.extension.valueCode",
-    )[0];
+      let isMasked = fhirpath.evaluate(patient, 'Patient.identifier.extension.valueCode')[0];
 
-    if (isMasked === 'masked') {
-      isMasked = true;
-    } else {
-      isMasked = false;
-    }
+      if (isMasked === 'masked') {
+        isMasked = true;
+      } else {
+        isMasked = false;
+      }
 
-    // if both MRN and name -- return string w / both
-    if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0 && !isMasked) {
-      const label = mrn.concat(': ').concat(name);
-      return <p className="accordion-result-label">{label}</p>;
-    }
-    if (typeof name === 'string' && name.length > 0) {
-      return <p className="accordion-result-label">{name}</p>;
-    }
-    if (typeof mrn === 'string' && mrn.length > 0) {
-      return <p className="accordion-result-label">{mrn}</p>;
+      // if both MRN and name -- return string w / both
+      if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0 && !isMasked) {
+        const label = mrn.concat(': ').concat(name);
+        return <p className="accordion-result-label">{label}</p>;
+      }
+      if (typeof name === 'string' && name.length > 0) {
+        return <p className="accordion-result-label">{name}</p>;
+      }
+      if (typeof mrn === 'string' && mrn.length > 0) {
+        return <p className="accordion-result-label">{mrn}</p>;
+      }
     }
 
     let label = 'Patient';

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -43,25 +43,30 @@ function Result(props) {
       props.bundle,
       "Bundle.descendants().resource.where(resourceType='Patient').name.text",
     )[0];
-    const resourceID = fhirpath.evaluate(
+
+    let isMasked = fhirpath.evaluate(
       props.bundle,
-      "Bundle.descendants().where(resource.resourceType='Patient').fullUrl",
+      "Bundle.descendants().resource.where(resourceType='Patient').identifier.extension.valueCode",
     )[0];
 
+    if (typeof isMasked === 'string' && isMasked === 'masked') {
+      isMasked = true;
+    } else {
+      isMasked = false;
+    }
+
     // if both MRN and name -- return string w / both
-    if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0) {
+    if (typeof mrn === 'string' && mrn.length > 0 && typeof name === 'string' && name.length > 0 && !isMasked) {
       const label = mrn.concat(': ').concat(name);
       return <p className="accordion-result-label">{label}</p>;
-    }
-    if (typeof mrn === 'string' && mrn.length > 0) {
-      return <p className="accordion-result-label">{mrn}</p>;
     }
     if (typeof name === 'string' && name.length > 0) {
       return <p className="accordion-result-label">{name}</p>;
     }
-    if (typeof resourceID === 'string' && resourceID.length > 0) {
-      return <p className="accordion-result-label">{resourceID}</p>;
+    if (typeof mrn === 'string' && mrn.length > 0) {
+      return <p className="accordion-result-label">{mrn}</p>;
     }
+
     let label = 'Patient';
     label = label.concat(' ').concat(props.id.toString());
     return <p className="accordion-result-label">{label}</p>;

--- a/react-app/src/components/Result.js
+++ b/react-app/src/components/Result.js
@@ -49,7 +49,7 @@ function Result(props) {
       "Bundle.descendants().resource.where(resourceType='Patient').identifier.extension.valueCode",
     )[0];
 
-    if (typeof isMasked === 'string' && isMasked === 'masked') {
+    if (isMasked === 'masked') {
       isMasked = true;
     } else {
       isMasked = false;

--- a/react-app/src/components/ResultPage.js
+++ b/react-app/src/components/ResultPage.js
@@ -14,7 +14,7 @@ function ResultPage(props) {
     <div>
       <Container fluid>
         <Row>
-          <Col xxl={3} xl={3} lg={3} md={3} sm={3} xs={3} className="sidebar-col">
+          <Col xxl={1} xl={1} lg={1} md={1} sm={1} xs={3} className="sidebar-col">
             <ResultSidebar
               extractedData={props.extractedData}
               loggedMessages={props.loggedMessages}

--- a/react-app/src/components/ResultPage.js
+++ b/react-app/src/components/ResultPage.js
@@ -14,7 +14,7 @@ function ResultPage(props) {
     <div>
       <Container fluid>
         <Row>
-          <Col xxl={1} xl={1} lg={1} md={1} sm={1} xs={3} className="sidebar-col">
+          <Col sm={1} xs={3} className="sidebar-col">
             <ResultSidebar
               extractedData={props.extractedData}
               loggedMessages={props.loggedMessages}

--- a/react-app/src/stylesheets/ResultPage.scss
+++ b/react-app/src/stylesheets/ResultPage.scss
@@ -41,3 +41,7 @@
   font-family: 'Courier New', 'Monaco', monospace;
   font-size: 60px;
 }
+
+.result-label {
+  overflow-wrap: break-word;
+}

--- a/react-app/src/stylesheets/ResultPage.scss
+++ b/react-app/src/stylesheets/ResultPage.scss
@@ -42,6 +42,7 @@
   font-size: 60px;
 }
 
-.result-label {
+.accordion-result-label {
   overflow-wrap: break-word;
+  max-width: 190px;
 }


### PR DESCRIPTION
### Summary
The patient label in the sidebar of the result page now changes based on available information in the JSON schema.

### New Behavior
Previously, the patients were all labelled "Patient X", where X was an iterator variable used to access the patient's bundle in extractedData. Now, the label changes based on available information:
1. If both an MRN and a name are available, they are displayed in this format: "MRN: First Last"
2. If either an MRN or a name is available, but not both, than the available data displays by itself
3. If neither an MRN nor a name is available, the patient resource ID displays
4. If a resource ID is unavailable, the old "Patient X" label is used.

### Code Changes
- Added function to Result component and modified JSX in return statement
- Changes to CSS classes so that the resource IDs (which are very long strings) don't overflow out of the sidebar. In order to get this working properly, I also made the sidebar a set width--previously, it only had a minimum width, and would expand at large window sizes, which looked odd.  

### Testing Guidance
1. Start the app with npm start. Click on "Extract New".
2. In patient-information.csv, delete the first and last name of one of the patients. Make sure that there is at least one other patient with their name available.
3. Upload this config file and run extraction. Look at the sidebar of the result page. The patients with names available should be labelled "MRN: First Last". The patient with no name should be labelled "MRN". If there is a patient with no data, they will be labelled "Patient X".
4. Add lines to the patient extractor in the configuration file in order to mask the MRNs:
`{
      "label": "patient",
      "type": "CSVPatientExtractor",
      "constructorArgs": {
        "filePath": "./sample-extraction-data/sample-client-data/patient-information.csv",
        "mask": [
          "mrn"
        ]
      }
    },
5. Click "Exit" in the result page. Upload the config file again and click "Submit". Look at the sidebar of the result page. The patients with names available will be labelled "First Last". The patient with no name will be labelled with the patient resource ID. If there's an empty patient, they will be labelled "Patient X".