### PR TITLE
Add Save As functionality and back buttons to config editor

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -91,10 +91,39 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
       const outputFile = path.join(savePath, `mcode-extraction-patient-${i + 1}.json`);
       fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
     });
-    // retuerning true indicates that the save process succeeded
+    // returning true indicates that the save process succeeded
     return true;
   } catch (error) {
     // return the error message
+    return error.message;
+  }
+});
+
+ipcMain.handle('save-config-as', async (event, schema) => {
+  try {
+    const options = {
+      defaultPath: app.getPath('downloads'),
+      properties: ['createDirectory'],
+    };
+    return dialog
+      .showSaveDialog(null, options)
+      .then((savePath) => {
+        if (!savePath.canceled) {
+          return savePath.filePath;
+        }
+        return null;
+      })
+      .then((savePath) => {
+        if (savePath !== null) {
+          fs.writeFileSync(savePath, JSON.stringify(schema), 'utf8');
+          // returning true indicates that the save process succeeded
+          return true;
+        }
+        // returning null indicates that the save process was cacelled
+        return savePath;
+      });
+  } catch (error) {
+    // returning a string indicates that an error occurred
     return error.message;
   }
 });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -100,30 +100,24 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
 });
 
 ipcMain.handle('save-config-as', async (event, schema) => {
-  try {
-    const options = {
-      defaultPath: app.getPath('downloads'),
-      properties: ['createDirectory'],
-    };
-    return dialog
-      .showSaveDialog(null, options)
-      .then((savePath) => {
-        if (!savePath.canceled) {
-          return savePath.filePath;
-        }
-        return null;
-      })
-      .then((savePath) => {
-        if (savePath !== null) {
-          fs.writeFileSync(savePath, JSON.stringify(schema), 'utf8');
-          // returning true indicates that the save process succeeded
-          return true;
-        }
-        // returning null indicates that the save process was cacelled
-        return savePath;
-      });
-  } catch (error) {
-    // returning a string indicates that an error occurred
-    return error.message;
-  }
+  const options = {
+    defaultPath: app.getPath('downloads'),
+    properties: ['createDirectory'],
+  };
+  return dialog
+    .showSaveDialog(null, options)
+    .then((savePath) => {
+      if (!savePath.canceled) {
+        return savePath.filePath;
+      }
+      return null;
+    })
+    .then((savePath) => {
+      if (savePath !== null) {
+        fs.writeFileSync(savePath, JSON.stringify(schema), 'utf8');
+      }
+      // returning a path indicates that the save process succeeded
+      // returning null indicates that the save process was cancelled
+      return savePath;
+    });
 });

--- a/electron/electron.js
+++ b/electron/electron.js
@@ -99,9 +99,10 @@ ipcMain.handle('save-output', async (event, savePath, extractedData) => {
   }
 });
 
-ipcMain.handle('save-config-as', async (event, schema) => {
+ipcMain.handle('save-config-as', async (event, configJSON) => {
   const options = {
     defaultPath: app.getPath('downloads'),
+    filters: [{ name: 'JSON', extensions: ['json'] }],
     properties: ['createDirectory'],
   };
   return dialog
@@ -114,7 +115,7 @@ ipcMain.handle('save-config-as', async (event, schema) => {
     })
     .then((savePath) => {
       if (savePath !== null) {
-        fs.writeFileSync(savePath, JSON.stringify(schema), 'utf8');
+        fs.writeFileSync(savePath, JSON.stringify(configJSON), 'utf8');
       }
       // returning a path indicates that the save process succeeded
       // returning null indicates that the save process was cancelled

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -26,4 +26,8 @@ contextBridge.exposeInMainWorld('api', {
     const result = await ipcRenderer.invoke('save-output', savePath, extractedData);
     return result;
   },
+  saveConfigAs: async (schema) => {
+    const result = await ipcRenderer.invoke('save-config-as', schema);
+    return result;
+  },
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -9,5 +9,5 @@ contextBridge.exposeInMainWorld('api', {
   getFile: async () => ipcRenderer.invoke('get-file'),
   getOutputPath: async () => ipcRenderer.invoke('get-output-path'),
   saveOutput: async (savePath, extractedData) => ipcRenderer.invoke('save-output', savePath, extractedData),
-  saveConfigAs: async (schema) => ipcRenderer.invoke('save-config-as', schema),
+  saveConfigAs: async (configJSON) => ipcRenderer.invoke('save-config-as', configJSON),
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -4,30 +4,10 @@ const { ipcRenderer, contextBridge } = require('electron');
 contextBridge.exposeInMainWorld('ipcRenderer', ipcRenderer);
 
 contextBridge.exposeInMainWorld('api', {
-  extract: async (fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) => {
-    //  call function in preload.js
-    const results = await ipcRenderer.invoke(
-      'run-extraction',
-      fromDate,
-      toDate,
-      configFilepath,
-      runLogFilepath,
-      debug,
-      allEntries,
-    );
-    return results;
-  },
+  extract: async (fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) =>
+    ipcRenderer.invoke('run-extraction', fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries),
   getFile: async () => ipcRenderer.invoke('get-file'),
-  getOutputPath: async () => {
-    const savePath = await ipcRenderer.invoke('get-output-path');
-    return savePath;
-  },
-  saveOutput: async (savePath, extractedData) => {
-    const result = await ipcRenderer.invoke('save-output', savePath, extractedData);
-    return result;
-  },
-  saveConfigAs: async (schema) => {
-    const result = await ipcRenderer.invoke('save-config-as', schema);
-    return result;
-  },
+  getOutputPath: async () => ipcRenderer.invoke('get-output-path'),
+  saveOutput: async (savePath, extractedData) => ipcRenderer.invoke('save-output', savePath, extractedData),
+  saveConfigAs: async (schema) => ipcRenderer.invoke('save-config-as', schema),
 });

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -21,7 +21,6 @@
         "react-bootstrap": "^2.0.0-beta.0",
         "react-dom": "^17.0.2",
         "react-json-view": "^1.21.3",
-        "react-router-bootstrap": "^0.25.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "web-vitals": "^1.0.1"
@@ -15920,18 +15919,6 @@
       },
       "peerDependencies": {
         "react": ">=15"
-      }
-    },
-    "node_modules/react-router-bootstrap": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
-      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
-      "dependencies": {
-        "prop-types": "^15.5.10"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0",
-        "react-router-dom": ">=4.0.0"
       }
     },
     "node_modules/react-router-dom": {
@@ -34150,14 +34137,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "react-router-bootstrap": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
-      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
-      "requires": {
-        "prop-types": "^15.5.10"
       }
     },
     "react-router-dom": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -16,7 +16,6 @@
     "react-bootstrap": "^2.0.0-beta.0",
     "react-dom": "^17.0.2",
     "react-json-view": "^1.21.3",
-    "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.0.1"

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -23,7 +23,7 @@ function ConfigEditor() {
     setShowForm(!showForm);
   }
   return (
-    <div className="page-container">
+    <div>
       <h1 className="page-title">Configuration Editor</h1>
       {!showForm && (
         <div className="button-container">

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -1,25 +1,44 @@
 import React, { useState } from 'react';
+import { LinkContainer } from 'react-router-bootstrap';
 import { Button } from 'react-bootstrap';
 
 import ConfigForm from './ConfigForm';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
+  const schema = {
+    $id: 'https://example.com/person.schema.json',
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    title: 'Person',
+    type: 'object',
+    properties: {
+      placeholder: {
+        type: 'string',
+        description: 'This is a placeholder for an actual config JSON schema',
+      },
+    },
+  };
 
   function toggleForm() {
     setShowForm(!showForm);
   }
   return (
-    <div>
+    <div className="page-container">
       <h1 className="page-title">Configuration Editor</h1>
       {!showForm && (
         <div className="button-container">
           <Button className="vertical-menu-button" variant="outline-secondary" onClick={toggleForm}>
             Create New
           </Button>
+
+          <Button className="vertical-menu-button" variant="outline-secondary" onClick={toggleForm}>
+            <LinkContainer to="/">
+              <p className="button-text">Back</p>
+            </LinkContainer>
+          </Button>
         </div>
       )}
-      {showForm && <ConfigForm />}
+      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} />}
     </div>
   );
 }

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -6,6 +6,7 @@ import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
+  const [containerClass, setContainerClass] = useState('flex-alignment-container');
   const schema = {
     $id: 'https://example.com/person.schema.json',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -20,10 +21,15 @@ function ConfigEditor() {
   };
 
   function toggleForm() {
+    if (showForm) {
+      setContainerClass('flex-alignment-container');
+    } else {
+      setContainerClass('page-container');
+    }
     setShowForm(!showForm);
   }
   return (
-    <div>
+    <div className={containerClass}>
       <h1 className="page-title">Configuration Editor</h1>
       {!showForm && (
         <div className="button-container">
@@ -33,7 +39,7 @@ function ConfigEditor() {
           <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>
       )}
-      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} />}
+      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} setContainerClass={setContainerClass} />}
     </div>
   );
 }

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -6,7 +6,6 @@ import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
-  const [containerClass, setContainerClass] = useState('flex-alignment-container');
   const schema = {
     $id: 'https://example.com/person.schema.json',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -21,15 +20,10 @@ function ConfigEditor() {
   };
 
   function toggleForm() {
-    if (showForm) {
-      setContainerClass('flex-alignment-container');
-    } else {
-      setContainerClass('page-container');
-    }
     setShowForm(!showForm);
   }
   return (
-    <div className={containerClass}>
+    <div className="flex-start-container">
       <h1 className="page-title">Configuration Editor</h1>
       {!showForm && (
         <div className="button-container">
@@ -39,7 +33,7 @@ function ConfigEditor() {
           <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>
       )}
-      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} setContainerClass={setContainerClass} />}
+      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} />}
     </div>
   );
 }

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
 import { Button } from 'react-bootstrap';
 
 import ConfigForm from './ConfigForm';
+import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
@@ -30,12 +30,7 @@ function ConfigEditor() {
           <Button className="vertical-menu-button" variant="outline-secondary" onClick={toggleForm}>
             Create New
           </Button>
-
-          <Button className="vertical-menu-button" variant="outline-secondary" onClick={toggleForm}>
-            <LinkContainer to="/">
-              <p className="button-text">Back</p>
-            </LinkContainer>
-          </Button>
+          <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>
       )}
       {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} />}

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -6,7 +6,7 @@ import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
-  const schema = {
+  const configJSON = {
     $id: 'https://example.com/person.schema.json',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Person',
@@ -14,7 +14,7 @@ function ConfigEditor() {
     properties: {
       placeholder: {
         type: 'string',
-        description: 'This is a placeholder for an actual config JSON schema',
+        description: 'This is a placeholder for an actual config JSON',
       },
     },
   };
@@ -33,7 +33,7 @@ function ConfigEditor() {
           <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>
       )}
-      {showForm && <ConfigForm schema={schema} setShowForm={setShowForm} />}
+      {showForm && <ConfigForm configJSON={configJSON} setShowForm={setShowForm} />}
     </div>
   );
 }

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -1,7 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Alert, Button } from 'react-bootstrap';
 
-function ConfigForm() {
-  return <p className="page-text text-centered">The config editor form will display here.</p>;
+function ConfigForm(props) {
+  const [showSavedAlert, setShowSavedAlert] = useState(false);
+  const [showErrorAlert, setShowErrorAlert] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  function onSaveAs() {
+    window.api
+      .saveConfigAs(props.schema)
+      .then((result) => {
+        if (result === true) {
+          // if saveOutput() returns true, then the save process succeeded
+          setShowSavedAlert(true);
+        } else if (typeof result === 'string') {
+          // if the result is a string, that means the save process returned an error message
+          setErrorMessage(result);
+          setShowErrorAlert(true);
+        }
+        // If result is null, the process was cancelled, and nothing should be done.
+      })
+      .catch((error) => {
+        setShowErrorAlert(true);
+        setErrorMessage(error.message);
+        setShowSavedAlert(false);
+      });
+  }
+  function onBack() {
+    props.setShowForm(false);
+  }
+  return (
+    <div className="page-container">
+      <p className="page-text text-centered">The config editor form will display here.</p>
+      {showSavedAlert && (
+        <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
+          <Alert.Heading>Files saved</Alert.Heading>
+        </Alert>
+      )}
+      {showErrorAlert && (
+        <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
+          <Alert.Heading>Error: Unable to save file</Alert.Heading>
+          <p>{errorMessage}</p>
+        </Alert>
+      )}
+      {!showSavedAlert && !showErrorAlert && (
+        <div className="nav-button-container">
+          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onBack}>
+            Back
+          </Button>
+          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onSaveAs}>
+            Save As
+          </Button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default ConfigForm;

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -24,10 +24,11 @@ function ConfigForm(props) {
       });
   }
   function onBack() {
+    props.setContainerClass('flex-alignment-container');
     props.setShowForm(false);
   }
   return (
-    <div className="page-container">
+    <div className="flex-alignment-container">
       <p className="page-text text-centered">The config editor form will display here.</p>
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -24,11 +24,10 @@ function ConfigForm(props) {
       });
   }
   function onBack() {
-    props.setContainerClass('flex-alignment-container');
     props.setShowForm(false);
   }
   return (
-    <div className="flex-alignment-container">
+    <div className="flex-space-between-container">
       <p className="page-text text-centered">The config editor form will display here.</p>
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -8,7 +8,7 @@ function ConfigForm(props) {
   const [errorMessage, setErrorMessage] = useState('');
   function onSaveAs() {
     window.api
-      .saveConfigAs(props.schema)
+      .saveConfigAs(props.configJSON)
       .then((result) => {
         if (result !== null) {
           // if saveOutput() returns true, then the save process succeeded

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -3,19 +3,17 @@ import { Alert, Button } from 'react-bootstrap';
 
 function ConfigForm(props) {
   const [showSavedAlert, setShowSavedAlert] = useState(false);
+  const [savedMessage, setSavedMessage] = useState('');
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   function onSaveAs() {
     window.api
       .saveConfigAs(props.schema)
       .then((result) => {
-        if (result === true) {
+        if (result !== null) {
           // if saveOutput() returns true, then the save process succeeded
           setShowSavedAlert(true);
-        } else if (typeof result === 'string') {
-          // if the result is a string, that means the save process returned an error message
-          setErrorMessage(result);
-          setShowErrorAlert(true);
+          setSavedMessage('Files saved to '.concat(result));
         }
         // If result is null, the process was cancelled, and nothing should be done.
       })
@@ -34,6 +32,7 @@ function ConfigForm(props) {
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
           <Alert.Heading>Files saved</Alert.Heading>
+          <p>{savedMessage}</p>
         </Alert>
       )}
       {showErrorAlert && (

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Col, Form, Row } from 'react-bootstrap';
+
+import LinkButton from './LinkButton';
 
 function Extract(props) {
   const [configPath, setConfigPath] = useState('No File Chosen');
@@ -162,11 +163,7 @@ function Extract(props) {
             </Row>
           </Form>
           <div className="nav-button-container">
-            <Button className="generic-button" size="lg" variant="outline-secondary">
-              <LinkContainer to="/">
-                <p className="button-text">Cancel</p>
-              </LinkContainer>
-            </Button>
+            <LinkButton className="generic-button" size="lg" variant="outline-secondary" text="Cancel" path="/" />
             <Button className="generic-button" size="lg" variant="outline-secondary" onClick={useSubmit}>
               Submit
             </Button>

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -162,11 +162,11 @@ function Extract(props) {
             </Row>
           </Form>
           <div className="nav-button-container">
-            <LinkContainer to="/">
-              <Button className="generic-button" size="lg" variant="outline-secondary">
-                Cancel
-              </Button>
-            </LinkContainer>
+            <Button className="generic-button" size="lg" variant="outline-secondary">
+              <LinkContainer to="/">
+                <p className="button-text">Cancel</p>
+              </LinkContainer>
+            </Button>
             <Button className="generic-button" size="lg" variant="outline-secondary" onClick={useSubmit}>
               Submit
             </Button>

--- a/react-app/src/components/ExtractionError.js
+++ b/react-app/src/components/ExtractionError.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
-import { Button } from 'react-bootstrap';
 import LogList from './LogList';
+import LinkButton from './LinkButton';
 
 function ExtractionError(props) {
   return (
@@ -12,11 +11,7 @@ function ExtractionError(props) {
         checked.
       </p>
       <div className="button-container">
-        <LinkContainer to="/extract">
-          <Button className="generic-button" size="lg" variant="outline-secondary">
-            Extract New
-          </Button>
-        </LinkContainer>
+        <LinkButton className="generic-button" variant="outline-secondary" text="Extract New" path="/extract" />
       </div>
       <LogList loggedMessages={props.loggedMessages} listType="" />
     </div>

--- a/react-app/src/components/Home.js
+++ b/react-app/src/components/Home.js
@@ -3,24 +3,20 @@ This is the landing page that will display when users first open the app. It has
 */
 
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
-import { Button } from 'react-bootstrap';
+import LinkButton from './LinkButton';
 
 function Home() {
   return (
     <div>
       <h1 className="page-title">Extractor UI</h1>
       <div className="button-container">
-        <LinkContainer to="/extract">
-          <Button className="vertical-menu-button" variant="outline-secondary">
-            Extract New
-          </Button>
-        </LinkContainer>
-        <LinkContainer to="/config-editor">
-          <Button className="vertical-menu-button" variant="outline-secondary">
-            Configuration File Editor
-          </Button>
-        </LinkContainer>
+        <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Extract New" path="/extract" />
+        <LinkButton
+          className="vertical-menu-button"
+          variant="outline-secondary"
+          text="Configuration File Editor"
+          path="/config-editor"
+        />
       </div>
     </div>
   );

--- a/react-app/src/components/LinkButton.js
+++ b/react-app/src/components/LinkButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { Button } from 'react-bootstrap';
+
+function LinkButton(props) {
+  const history = useHistory();
+  const onClick = () => {
+    history.push(props.path);
+  };
+  return (
+    <Button className={props.className} variant={props.variant} onClick={onClick}>
+      {props.text}
+    </Button>
+  );
+}
+
+export default LinkButton;

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -126,6 +126,10 @@
   margin-top: 0px;
 }
 
+.button-text {
+  margin-bottom: 0px;
+}
+
 .file-name {
   color: $secondary;
   font-weight: bold;

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -8,12 +8,20 @@
   justify-content: space-between;
 }
 
-.flex-alignment-container {
+.flex-space-between-container {
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
   height: 100%;
   justify-content: space-between;
+}
+
+.flex-start-container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 100vh;
+  justify-content: flex-start;
 }
 
 .form-container {

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -8,6 +8,14 @@
   justify-content: space-between;
 }
 
+.flex-alignment-container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 100%;
+  justify-content: space-between;
+}
+
 .form-container {
   padding-left: 20px;
   padding-right: 20px;
@@ -124,10 +132,6 @@
   margin-bottom: 0px;
   margin-right: 20px;
   margin-top: 0px;
-}
-
-.button-text {
-  margin-bottom: 0px;
 }
 
 .file-name {


### PR DESCRIPTION
### Summary
The config editor now has functional "Back" and "Save As" buttons. Additionally, I found a fix for the bug where Buttons in LinkContainers always have active styling.

### New Behavior
The config menu has a back button that redirects to the home page. The config editor has a back button that toggles back to the config menu. The config editor has a "Save As" button which allows the user to save the config schema. If the save process succeeds, a green success alert appears. If the save process fails, a red error alert appears and displays the error message. If the user cancels the save process, the save dialog disappears and no alert displays.

### Code Changes
- Added "Back" button to config menu
- Added "Back" and "Save As" buttons to ConfigForm, along with associated functions
- Added save-config-as functions to backend (preload.js & electron.js)
- Added button-text CSS style in order to get around the LinkContainer active styling bug
- Added schema variable to ConfigEditor. The variable currently contains a placeholder JSON schema for testing purposes.

### Testing Guidance
Start the app with npm start. Click "Configuration File Editor". Click "Back". You will return to the home page. Click on "Configuration File Editor" again. Click on "Create New". The ConfigForm component will appear. Click "Back" to go back to the config menu. Click on "Save As" to open the save dialog and save the schema. If it succeeds, a green success alert will appear. If it fails, a red error message alert will appear. If you click "Cancel", the save dialog will disappear and nothing will happen in the app.
