### PR TITLE
Config load button

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -75,6 +75,8 @@ ipcMain.handle('get-file', async () =>
   }),
 );
 
+ipcMain.handle('read-file', async (event, filePath) => fs.readFileSync(filePath, 'utf8'));
+
 ipcMain.handle('get-output-path', async () => {
   const options = {
     buttonLabel: 'Save',

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('api', {
   extract: async (fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) =>
     ipcRenderer.invoke('run-extraction', fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries),
   getFile: async () => ipcRenderer.invoke('get-file'),
+  readFile: async (filePath) => ipcRenderer.invoke('read-file', filePath),
   getOutputPath: async () => ipcRenderer.invoke('get-output-path'),
   saveOutput: async (savePath, extractedData) => ipcRenderer.invoke('save-output', savePath, extractedData),
   saveConfigAs: async (configJSON) => ipcRenderer.invoke('save-config-as', configJSON),

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { Button } from 'react-bootstrap';
+import { Alert, Button } from 'react-bootstrap';
 
 import ConfigForm from './ConfigForm';
 import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
+  const [showErrorAlert, setShowErrorAlert] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
   const [configJSON, setConfigJSON] = useState({
     $id: 'https://example.com/person.schema.json',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -45,7 +47,8 @@ function ConfigEditor() {
         }
       })
       .catch((error) => {
-        console.log(error);
+        setErrorMessage(error.message);
+        setShowErrorAlert(true);
       });
   }
 
@@ -62,6 +65,12 @@ function ConfigEditor() {
           </Button>
           <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>
+      )}
+      {showErrorAlert && (
+        <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
+          <Alert.Heading>Error: Unable to load file</Alert.Heading>
+          <p>{errorMessage}</p>
+        </Alert>
       )}
       {showForm && <ConfigForm configJSON={configJSON} setShowForm={setShowForm} />}
     </div>

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -67,10 +67,12 @@ function ConfigEditor() {
         </div>
       )}
       {showErrorAlert && (
-        <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
-          <Alert.Heading>Error: Unable to load file</Alert.Heading>
-          <p>{errorMessage}</p>
-        </Alert>
+        <div className="flex-end-container">
+          <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
+            <Alert.Heading>Error: Unable to load file</Alert.Heading>
+            <p>{errorMessage}</p>
+          </Alert>
+        </div>
       )}
       {showForm && <ConfigForm configJSON={configJSON} setShowForm={setShowForm} />}
     </div>

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -6,7 +6,7 @@ import LinkButton from './LinkButton';
 
 function ConfigEditor() {
   const [showForm, setShowForm] = useState(false);
-  const configJSON = {
+  const [configJSON, setConfigJSON] = useState({
     $id: 'https://example.com/person.schema.json',
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Person',
@@ -17,11 +17,38 @@ function ConfigEditor() {
         description: 'This is a placeholder for an actual config JSON',
       },
     },
-  };
+  });
 
   function toggleForm() {
     setShowForm(!showForm);
   }
+
+  function loadFile() {
+    window.api
+      .getFile()
+      .then((result) => {
+        if (result.filePaths[0] !== undefined) {
+          return window.api.readFile(result.filePaths[0]);
+        }
+        return null;
+      })
+      .then((result) => {
+        if (result !== null) {
+          setConfigJSON(JSON.parse(result));
+          return true;
+        }
+        return null;
+      })
+      .then((result) => {
+        if (result) {
+          setShowForm(true);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
+
   return (
     <div className="flex-start-container">
       <h1 className="page-title">Configuration Editor</h1>
@@ -29,6 +56,9 @@ function ConfigEditor() {
         <div className="button-container">
           <Button className="vertical-menu-button" variant="outline-secondary" onClick={toggleForm}>
             Create New
+          </Button>
+          <Button className="vertical-menu-button" variant="outline-secondary" onClick={loadFile}>
+            Load File
           </Button>
           <LinkButton className="vertical-menu-button" variant="outline-secondary" text="Back" path="/" />
         </div>

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -24,6 +24,14 @@
   justify-content: flex-start;
 }
 
+.flex-end-container {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 100vh;
+  justify-content: flex-end;
+}
+
 .form-container {
   padding-left: 20px;
   padding-right: 20px;


### PR DESCRIPTION
### Summary
The config editor menu now has a button to load a pre-existing schema.

### New Behavior
The config menu has a button labelled "Load File". When clicked, it opens a dialog.showOpenDialog window and allows the user to select a JSON file. It then reads this file and stores its contents as a JSON object. The app then displays then ConfigForm placeholder, passing the config file to it.

### Code Changes
- Made configJSON a state variable with associated functions
- Added functions to connect to backend for both selecting and reading the file
- Added error alert that displays at the bottom of the page if the process throws an error

### Testing Guidance
Start the app with npm start. Click on "Configuration Editor". Click on "Load File". Select a file (the dialog will only allow you to select .json files). Click "Open". If the .json file you select is valid, the config menu will disappear, and the placeholder text from the ConfigForm will display. To check the value of the configJSON prop passed to the form, place a console.log(props.configJSON) statement in the ConfigForm function.
To trigger the error alert, make the JSON file invalid (ex. delete a bracket) and attempt to load it. The error alert will display at the bottom of the page. Click the X in the corner to close the alert.