### PR TITLE
Centered processing text and cancel button

### DIFF
--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -171,11 +171,13 @@ function Extract(props) {
         </div>
       )}
       {submitted && (
-        <div>
-          <p>The form as been submitted. Running extraction...</p>
-          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onReset}>
-            Reset
-          </Button>
+        <div className="flex-start-container">
+          <p className="page-text text-centered">The form as been submitted. Running extraction...</p>
+          <div className="button-container">
+            <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onReset}>
+              Cancel
+            </Button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
### Summary
The text and cancel button that display while the extractor runs are now centered.

### New behavior
Centered button and text on the Extract page.

### Code Changes
- Added CSS classes to <p> containing processing message
- Added CSS class to div containing message and button
- Placed button inside a div with a CSS class

Testing Guidance
Start the app with npm start. Run extraction. The processing page will appear briefly. To look at the processing page for more than a couple of seconds, modify the conditional statements in lines 89 and 173 to change what displays:

Line 89 Original
`{!submitted && (`
Line 89 for Testing
`{submitted && ('

Line 173 Original
`{submitted && (`
Line 173 for Testing
'{!submitted && ('

The Extract page will now display the processing message, so you will be able to look at it for longer.