### PR TITLE
Load framework config

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -63,10 +63,7 @@ app.on('activate', () => {
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and import them here.
 
-ipcMain.handle('get-config-schema', async () => {
-  console.log('electron.js: ', configSchema);
-  return configSchema;
-});
+ipcMain.handle('get-config-schema', async () => configSchema);
 
 ipcMain.handle('get-file', async () =>
   dialog.showOpenDialog(mainWindow, {

--- a/electron/extraction.js
+++ b/electron/extraction.js
@@ -1,4 +1,4 @@
-const { logger, mcodeApp, MCODEClient } = require('mcode-extraction-framework');
+const { getConfig, logger, mcodeApp, MCODEClient } = require('mcode-extraction-framework');
 
 async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) {
   try {
@@ -14,11 +14,12 @@ async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, d
     if (!debug) {
       defaultDebug = undefined;
     }
+    const config = getConfig(configFilepath);
     const extractedData = await mcodeApp(
       MCODEClient,
       defaultFromDate,
       defaultToDate,
-      configFilepath,
+      config,
       runLogFilepath,
       defaultDebug,
       allEntries,

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -6,9 +6,10 @@ contextBridge.exposeInMainWorld('ipcRenderer', ipcRenderer);
 contextBridge.exposeInMainWorld('api', {
   extract: async (fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) =>
     ipcRenderer.invoke('run-extraction', fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries),
+  getConfigSchema: async () => ipcRenderer.invoke('get-config-schema'),
   getFile: async () => ipcRenderer.invoke('get-file'),
-  readFile: async (filePath) => ipcRenderer.invoke('read-file', filePath),
   getOutputPath: async () => ipcRenderer.invoke('get-output-path'),
+  readFile: async (filePath) => ipcRenderer.invoke('read-file', filePath),
   saveOutput: async (savePath, outputBundles, saveLogs) =>
     ipcRenderer.invoke('save-output', savePath, outputBundles, saveLogs),
   saveConfigAs: async (configJSON) => ipcRenderer.invoke('save-config-as', configJSON),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0",
-        "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+        "mcode-extraction-framework": "github:mcode/mcode-extraction-framework#develop",
         "strip-ansi": "^6.0.0",
         "winston-transport": "^4.4.0"
       },
@@ -4600,11 +4600,12 @@
     },
     "node_modules/mcode-extraction-framework": {
       "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#7190191f5c4ea6f6c8f2ba5e3ef928ab7dfd296c",
+      "resolved": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#a92a233df44b59529fd3bd2ba2f0aac3aa3f649e",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",
+        "axios": "^0.21.1",
         "commander": "^6.2.0",
         "csv-parse": "^4.8.8",
         "fhir-crud-client": "^1.2.2",
@@ -10753,11 +10754,12 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#7190191f5c4ea6f6c8f2ba5e3ef928ab7dfd296c",
-      "from": "mcode-extraction-framework@git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+      "version": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#a92a233df44b59529fd3bd2ba2f0aac3aa3f649e",
+      "from": "mcode-extraction-framework@github:mcode/mcode-extraction-framework#develop",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",
+        "axios": "^0.21.1",
         "commander": "^6.2.0",
         "csv-parse": "^4.8.8",
         "fhir-crud-client": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0",
-    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+    "mcode-extraction-framework": "github:mcode/mcode-extraction-framework#develop",
     "strip-ansi": "^6.0.0",
     "winston-transport": "^4.4.0"
   },

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
+import { getConfigSchema } from './SchemaFormUtils';
 
 function ConfigForm(props) {
   const [showSavedAlert, setShowSavedAlert] = useState(false);
   const [savedMessage, setSavedMessage] = useState('');
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+
+  // DELETE ME
+  getConfigSchema().then((schema) => {
+    console.log(schema);
+  });
+
   function onSaveAs() {
     window.api
       .saveConfigAs(props.configJSON)

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -1,17 +1,11 @@
 import React, { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
-import { getConfigSchema } from './SchemaFormUtils';
 
 function ConfigForm(props) {
   const [showSavedAlert, setShowSavedAlert] = useState(false);
   const [savedMessage, setSavedMessage] = useState('');
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-
-  // DELETE ME
-  getConfigSchema().then((schema) => {
-    console.log(schema);
-  });
 
   function onSaveAs() {
     window.api

--- a/react-app/src/components/SchemaFormUtils.js
+++ b/react-app/src/components/SchemaFormUtils.js
@@ -1,0 +1,5 @@
+function getConfigSchema() {
+  return window.api.getConfigSchema();
+}
+
+module.exports = { getConfigSchema };


### PR DESCRIPTION
### Summary
The extraction process has been modified to accommodate the change to the config parameter of the mcodeApp function. Backend functions have been added to retrieve the config file schema.

### New Behavior
The app behavior hasn't visibly changed.

### Code Changes
- During extraction, extraction.js calls the getConfig function from the framework. This function takes the file path and returns the JSON object in that file. This object is passed to mcodeApp instead of the file path.
- schemaFormUtils, preload.js, and electron.js now have a chain of functions to retrieve the config file schema from the framework.
- Updated the mcode-extraction-framework dependency to the latest version of the develop branch

### Testing Guidance
Start the app with npm start. Run extraction. It will not throw an error related to the data type of the config file.
In order to see the schema returned by the new functions, add this import statement to ConfigForm.js:
`import { getConfigSchema } from './SchemaFormUtils';`
Add this code inside the ConfigForm function:
`getConfigSchema().then((schema) => {
    console.log(schema);
  });`

Go to the configuration editor. Click on "Create New". The config schema will log in the console.