### PR TITLE
Render extractor array

### DIFF
--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -33,7 +33,9 @@ function ConfigForm(props) {
   return (
     <div className="flex-space-between-container">
       <p className="page-text text-centered">The config editor form will display here.</p>
-      <Form schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} />
+      <div className="form-container">
+        <Form schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} />
+      </div>
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
           <Alert.Heading>Files saved</Alert.Heading>

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -1,3 +1,6 @@
+import React, { useState } from 'react';
+import { Accordion, FloatingLabel, Form } from 'react-bootstrap';
+
 function getConfigSchema() {
   return window.api.getConfigSchema();
 }
@@ -67,8 +70,99 @@ const uiSchema = {
   },
 };
 
+function Extractor(props) {
+  return (
+    <Accordion.Item eventKey={props.eventKey}>
+      <Accordion.Header>{props.formData.type}</Accordion.Header>
+      <Accordion.Body>
+        <p>This is a placeholder for an extractor. An input form will be added here.</p>
+      </Accordion.Body>
+    </Accordion.Item>
+  );
+}
+
+function ExtractorArray(props) {
+  const [extractors, setExtractors] = useState([]);
+  const [extractorsJSX, setExtractorsJSX] = useState([]);
+  const [types, setTypes] = useState([
+    'BaseFHIRExtractor',
+    'CSVAdverseEventExtractor',
+    'CSVCancerDiseaseStatusExtractor',
+    'CSVCancerRelatedMedicationExtractor',
+    'CSVClinicalTrialInformationExtractor',
+    'CSVConditionExtractor',
+    'CSVObservationExtractor',
+    'CSVPatientExtractor',
+    'CSVProcedureExtractor',
+    'CSVStagingExtractor',
+    'CSVTreatmentPlanChangeExtractor',
+    'Extractor',
+    'FHIRAdverseEventExtractor',
+    'FHIRAllergyIntoleranceExtractor',
+    'FHIRConditionExtractor',
+    'FHIRDocumentReferenceExtractor',
+    'FHIREncounterExtractor',
+    'FHIRMedicationOrderExtractor',
+    'FHIRMedicationRequestExtractor',
+    'FHIRMedicationStatementExtractor',
+    'FHIRObservationExtractor',
+    'FHIRPatientExtractor',
+    'FHIRProcedureExtractor',
+    'MCODERadiationProcedureExtractor',
+    'MCODESurgicalProcedureExtractor',
+  ]);
+
+  const getFormattedTypes = () =>
+    types.map((type) => (
+      <option value={type} key={type}>
+        {type}
+      </option>
+    ));
+
+  function getDefaultExtractorObj(type = '') {
+    return {
+      label: '',
+      type,
+      constructorArgs: {
+        filePath: 'No File Chosen',
+      },
+    };
+  }
+
+  function addExtractor(e) {
+    // Remove selected type from dropdown
+    const newTypes = types.filter((type) => type !== e.target.value);
+
+    // update list of extractors, the JSX display, and the formData object
+    const tempExtractors = [...extractors, getDefaultExtractorObj(e.target.value)];
+    const tempExtractorsJSX = tempExtractors.map((extractor, i) => (
+      <Extractor formData={extractor} eventKey={i} key={i} />
+    ));
+    setExtractorsJSX(tempExtractorsJSX);
+    setExtractors(tempExtractors);
+    props.onChange(tempExtractors);
+    setTypes(newTypes);
+    e.target.value = 'default';
+  }
+
+  return (
+    <div>
+      <h1 className="form-header-text">Extractors</h1>
+      <Accordion defaultActiveKey="0">{extractorsJSX}</Accordion>
+      <div className="form-button-container">
+        <Form.Select onChange={addExtractor} className="form-select">
+          <option value="default">Add new extractor</option>
+          {getFormattedTypes()}
+        </Form.Select>
+      </div>
+    </div>
+  );
+}
+
 const widgets = {};
 
-const fields = {};
+const fields = {
+  ArrayField: ExtractorArray,
+};
 
-module.exports = { getConfigSchema, uiSchema, widgets, fields };
+export { getConfigSchema, uiSchema, widgets, fields };

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -84,8 +84,7 @@ function Extractor(props) {
 function ExtractorArray(props) {
   const [extractors, setExtractors] = useState([]);
   const [extractorsJSX, setExtractorsJSX] = useState([]);
-  const [types, setTypes] = useState([
-    'BaseFHIRExtractor',
+  const types = [
     'CSVAdverseEventExtractor',
     'CSVCancerDiseaseStatusExtractor',
     'CSVCancerRelatedMedicationExtractor',
@@ -96,21 +95,7 @@ function ExtractorArray(props) {
     'CSVProcedureExtractor',
     'CSVStagingExtractor',
     'CSVTreatmentPlanChangeExtractor',
-    'Extractor',
-    'FHIRAdverseEventExtractor',
-    'FHIRAllergyIntoleranceExtractor',
-    'FHIRConditionExtractor',
-    'FHIRDocumentReferenceExtractor',
-    'FHIREncounterExtractor',
-    'FHIRMedicationOrderExtractor',
-    'FHIRMedicationRequestExtractor',
-    'FHIRMedicationStatementExtractor',
-    'FHIRObservationExtractor',
-    'FHIRPatientExtractor',
-    'FHIRProcedureExtractor',
-    'MCODERadiationProcedureExtractor',
-    'MCODESurgicalProcedureExtractor',
-  ]);
+  ];
 
   const getFormattedTypes = () =>
     types.map((type) => (
@@ -130,9 +115,6 @@ function ExtractorArray(props) {
   }
 
   function addExtractor(eventKey) {
-    // Remove selected type from dropdown
-    const newTypes = types.filter((type) => type !== eventKey);
-
     // update list of extractors, the JSX display, and the formData object
     const tempExtractors = [...extractors, getDefaultExtractorObj(eventKey)];
     const tempExtractorsJSX = tempExtractors.map((extractor, i) => (
@@ -141,7 +123,6 @@ function ExtractorArray(props) {
     setExtractorsJSX(tempExtractorsJSX);
     setExtractors(tempExtractors);
     props.onChange(tempExtractors);
-    setTypes(newTypes);
   }
 
   function sortExtractorsByType() {

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Accordion, FloatingLabel, Form } from 'react-bootstrap';
+import { Accordion, Button, Dropdown } from 'react-bootstrap';
 
 function getConfigSchema() {
   return window.api.getConfigSchema();
@@ -114,9 +114,9 @@ function ExtractorArray(props) {
 
   const getFormattedTypes = () =>
     types.map((type) => (
-      <option value={type} key={type}>
+      <Dropdown.Item value={type} eventKey={type} key={type}>
         {type}
-      </option>
+      </Dropdown.Item>
     ));
 
   function getDefaultExtractorObj(type = '') {
@@ -129,12 +129,12 @@ function ExtractorArray(props) {
     };
   }
 
-  function addExtractor(e) {
+  function addExtractor(eventKey) {
     // Remove selected type from dropdown
-    const newTypes = types.filter((type) => type !== e.target.value);
+    const newTypes = types.filter((type) => type !== eventKey);
 
     // update list of extractors, the JSX display, and the formData object
-    const tempExtractors = [...extractors, getDefaultExtractorObj(e.target.value)];
+    const tempExtractors = [...extractors, getDefaultExtractorObj(eventKey)];
     const tempExtractorsJSX = tempExtractors.map((extractor, i) => (
       <Extractor formData={extractor} eventKey={i} key={i} />
     ));
@@ -142,19 +142,50 @@ function ExtractorArray(props) {
     setExtractors(tempExtractors);
     props.onChange(tempExtractors);
     setTypes(newTypes);
-    e.target.value = 'default';
+  }
+
+  function sortExtractorsByType() {
+    // alphabetize
+    const tempExtractors = extractors;
+    tempExtractors.sort((a, b) => {
+      if (a.type > b.type) {
+        return 1;
+      }
+      if (a.type < b.type) {
+        return -1;
+      }
+      return 0;
+    });
+    // update list of extractors, the JSX display, and the formData object
+    const tempExtractorsJSX = tempExtractors.map((extractor, i) => (
+      <Extractor formData={extractor} eventKey={i} key={i} />
+    ));
+    setExtractorsJSX(tempExtractorsJSX);
+    setExtractors(tempExtractors);
+    props.onChange(tempExtractors);
   }
 
   return (
     <div>
       <h1 className="form-header-text">Extractors</h1>
-      <Accordion defaultActiveKey="0">{extractorsJSX}</Accordion>
       <div className="form-button-container">
-        <Form.Select onChange={addExtractor} className="form-select">
-          <option value="default">Add new extractor</option>
-          {getFormattedTypes()}
-        </Form.Select>
+        <Button
+          variant="outline-info"
+          className="narrow-button form-button"
+          onClick={sortExtractorsByType}
+          disabled={extractors.length < 1}
+        >
+          Sort by Type
+        </Button>
+        <Dropdown onSelect={addExtractor}>
+          <Dropdown.Toggle variant="outline-info" id="dropdown-basic" className="form-button">
+            Add new extractor
+          </Dropdown.Toggle>
+          <Dropdown.Menu>{getFormattedTypes()}</Dropdown.Menu>
+        </Dropdown>
       </div>
+      <Accordion defaultActiveKey="0">{extractorsJSX}</Accordion>
+      <div className="form-button-container"></div>
     </div>
   );
 }

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -172,9 +172,6 @@
   //font-size: 18px;
 }
 
-.form-select {
-  max-width: 200px;
-}
 .file-name {
   color: $secondary;
   font-weight: bold;

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -85,6 +85,12 @@
   font-weight: bold;
 }
 
+.form-header-text {
+  font-size: 30px;
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
+
 .text-centered {
   text-align: center;
 }
@@ -150,6 +156,25 @@
   margin-top: 0px;
 }
 
+.form-container {
+  max-width: 100%;
+}
+
+.form-button-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  margin-bottom: 30px;
+  margin-top: 30px;
+}
+.form-button {
+  font-family: 'Courier New', 'Monaco', monospace;
+  //font-size: 18px;
+}
+
+.form-select {
+  max-width: 200px;
+}
 .file-name {
   color: $secondary;
   font-weight: bold;


### PR DESCRIPTION
### Summary
The config form now renders an accordion for the extractor array. Each extractor has its own accordion item. There is a dropdown to add new extractors. There is a button to sort the selected extractors by type; this button is disabled until there is at least one extractor added

### New Behavior
The user can select extractors from a dropdown to add them to the array. The user can sort the extractors by type.

### Code Changes
- Added ExtractorArray and Extractor components to schemaFormUtils.js
- Added CSS styles to Pages.scss
- Placed container around <Form /> in ConfigEditor so that there is a margin around the form, instead of inputs starting at stopping at the very edge of the window

### Testing Guidance
Start the app with npm start. Click on "Configuration File Editor". Click on either "Create New" or "Load File". In the config form, scroll down to the extractors section. Try to hover over or click the "Sort by Type" button; it's disabled, so nothing will happen. Click on "Add new extractor" and select an extractor. The extractor will appear below the buttons in the accordion; its name will disappear from the "Add new extractor" list; and the "Sort by Type" button will no longer be disabled. Hover over and click on the sort button; nothing will happen, since there's only one extractor. Add as many extractors as you want, in any order. Click on the sort button to sort by type. Add more extractors and click the button again; the extractors will sort by type again.

