### PR TITLE
Custom file picker

### DIFF
--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -99,6 +99,7 @@ function Extract(props) {
                   filePath={configPath}
                   onClick={setConfig}
                   onClear={clearConfig}
+                  required={true}
                 />
                 <FilePicker
                   controlId="formLogPath"

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 
+import FilePicker from './FilePicker';
 import LinkButton from './LinkButton';
 
 function Extract(props) {
@@ -91,34 +92,22 @@ function Extract(props) {
           <Form className="form-container">
             <Row>
               <Col>
-                <Form.Group controlId="formConfigPath" className="mb-3">
-                  <Form.Label className="form-label">Select Configuration File</Form.Label>
-                  <div className="file-picker-box">
-                    <div className="file-button-container">
-                      <Button className="generic-button narrow-button" variant="outline-info" onClick={setConfig}>
-                        Upload File
-                      </Button>
-                      <Button className="generic-button narrow-button" variant="outline-info" onClick={clearConfig}>
-                        Clear
-                      </Button>
-                    </div>
-                    <Form.Label className="form-label file-name">{configPath}</Form.Label>
-                  </div>
-                </Form.Group>
-                <Form.Group controlId="formLogPath">
-                  <Form.Label className="form-label">Select Log File</Form.Label>
-                  <div className="file-picker-box">
-                    <div className="file-button-container">
-                      <Button className="generic-button narrow-button" variant="outline-info" onClick={setLog}>
-                        Upload File
-                      </Button>
-                      <Button className="generic-button narrow-button" variant="outline-info" onClick={clearLog}>
-                        Clear
-                      </Button>
-                    </div>
-                    <Form.Label className="form-label file-name">{logPath}</Form.Label>
-                  </div>
-                </Form.Group>
+                <FilePicker
+                  controlId="formConfigPath"
+                  label="Select Configuration File"
+                  buttonText="Upload File"
+                  filePath={configPath}
+                  onClick={setConfig}
+                  onClear={clearConfig}
+                />
+                <FilePicker
+                  controlId="formLogPath"
+                  label="Select Log File"
+                  buttonText="Upload File"
+                  filePath={logPath}
+                  onClick={setLog}
+                  onClear={clearLog}
+                />
                 <Form.Group controlId="formIncludeDebug">
                   <Form.Check
                     type="checkbox"

--- a/react-app/src/components/FilePicker.js
+++ b/react-app/src/components/FilePicker.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Button, Form } from 'react-bootstrap';
+
+/*
+PROPS:
+label - text that will display above picker. Optional.
+buttonText - text that will display on first button, informing the user of its purpose
+filePath - variable to store the file path (type string) selected by the user.
+onClick - function to call when the first button is clicked
+onClear - function to reset filePath
+required - boolean telling the picker whether to use required styling or not. Optional.
+*/
+export default function FilePicker(props) {
+  return (
+    <Form.Group controlId={props.controlId} className="mb-3">
+      {props.label && (
+        <Form.Label className="form-label">
+          {props.label}
+          {props.required && '*'}
+        </Form.Label>
+      )}
+      <div className="file-picker-box">
+        <div className="file-button-container">
+          <Button className="generic-button narrow-button" variant="outline-info" onClick={props.onClick}>
+            {props.buttonText}
+          </Button>
+          <Button className="generic-button narrow-button" variant="outline-info" onClick={props.onClear}>
+            Clear
+          </Button>
+        </div>
+        <Form.Label className="form-label file-name">{props.filePath}</Form.Label>
+      </div>
+    </Form.Group>
+  );
+}

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Accordion, Button, Dropdown } from 'react-bootstrap';
+import FilePicker from './FilePicker';
 
 function getConfigSchema() {
   return window.api.getConfigSchema();
@@ -7,7 +8,8 @@ function getConfigSchema() {
 
 const uiSchema = {
   patientIdCsvPath: {
-    classNames: 'page-text',
+    'ui:label': false,
+    'ui:widget': 'file',
   },
   commonExtractorArgs: {
     classNames: 'page-text',
@@ -171,7 +173,46 @@ function ExtractorArray(props) {
   );
 }
 
-const widgets = {};
+function FileWidget(props) {
+  let startingPath = 'No File Selected';
+  if (props.value) {
+    startingPath = props.value;
+  }
+  const [path, setPath] = useState(startingPath);
+
+  function setFilePath(newPath) {
+    setPath(newPath);
+    props.onChange(newPath);
+  }
+
+  function onClear() {
+    setPath('No File Selected');
+  }
+  function getFile() {
+    window.api.getFile().then((promise) => {
+      if (promise.filePaths[0] !== undefined) {
+        setPath(promise.filePaths[0]);
+        props.onChange(promise.filePaths[0]);
+      }
+    });
+  }
+  return (
+    <FilePicker
+      buttonText="Select File"
+      controlId={props.label}
+      onClick={getFile}
+      setFilePath={setFilePath}
+      filePath={path}
+      label={props.label}
+      onClear={onClear}
+      required={props.required}
+    />
+  );
+}
+
+const widgets = {
+  FileWidget,
+};
 
 const fields = {
   ArrayField: ExtractorArray,


### PR DESCRIPTION
### Summary
The file picker used in the UI has been made into a separate component. schemaFormUtils uses this custom component to create a custom FileWidget.

### New Behavior
The ConfigForm now renders a custom FileWidget for the patientIdCsvPath input.

### Code Changes
- Added FilePicker component
- Modified extraction form to use the FilePicker (no visible change in behavior)
- Added custom FileWidget to schemaFormUtils, and added this widget to the widgets object. FileWidget receives props from the react-jsonschema-form. It passes the necessary functions and data (declaring them where necessary) to the FilePicker.

### Testing Guidance
Start the app with npm start. Click on "Extract New". The file pickers on the extraction form will work as they always have. Go to the configuration editor. The patientIdCsvPath field (near the top of the page) renders the same file picker. You can select a file and clear it.