### PR TITLE
Custom string input

### DIFF
--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -211,26 +211,12 @@ function FileWidget(props) {
   );
 }
 
-function StringInput(props) {
-  console.log(props);
-  return (
-    <Form.Group className="mb-3" controlId="props.name">
-      <Form.Label>
-        {props.schema.title}
-        {props.required && '*'}
-      </Form.Label>
-      <Form.Control type="text" />
-    </Form.Group>
-  );
-}
-
 const widgets = {
   FileWidget,
 };
 
 const fields = {
   ArrayField: ExtractorArray,
-  StringField: StringInput,
 };
 
 export { getConfigSchema, uiSchema, widgets, fields };

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Accordion, Button, Dropdown, Form } from 'react-bootstrap';
+import { Accordion, Button, Dropdown } from 'react-bootstrap';
 import FilePicker from './FilePicker';
 
 function getConfigSchema() {

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Accordion, Button, Dropdown } from 'react-bootstrap';
+import { Accordion, Button, Dropdown, Form } from 'react-bootstrap';
 import FilePicker from './FilePicker';
 
 function getConfigSchema() {
@@ -210,12 +210,26 @@ function FileWidget(props) {
   );
 }
 
+function StringInput(props) {
+  console.log(props);
+  return (
+    <Form.Group className="mb-3" controlId="props.name">
+      <Form.Label>
+        {props.schema.title}
+        {props.required && '*'}
+      </Form.Label>
+      <Form.Control type="text" />
+    </Form.Group>
+  );
+}
+
 const widgets = {
   FileWidget,
 };
 
 const fields = {
   ArrayField: ExtractorArray,
+  StringField: StringInput,
 };
 
 export { getConfigSchema, uiSchema, widgets, fields };

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -10,62 +10,63 @@ const uiSchema = {
   patientIdCsvPath: {
     'ui:label': false,
     'ui:widget': 'file',
+    classNames: '',
   },
   commonExtractorArgs: {
-    classNames: 'page-text',
+    classNames: '',
     baseFhirUrl: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
     requestHeaders: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
   },
   notificationInfo: {
-    classNames: 'page-text',
+    classNames: '',
     host: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
     port: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
     from: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
     to: {
-      classNames: 'page-text',
+      classNames: 'input-width-limit',
     },
     tlsRejectUnauthorized: {
-      classNames: 'page-text',
+      classNames: '',
     },
   },
   extractors: {
     extractor: {
-      classNames: 'page-text',
+      classNames: '',
       label: {
-        classNames: 'page-text',
+        classNames: 'input-width-limit',
       },
       type: {
-        classNames: 'page-text',
+        classNames: '',
       },
       constructorArgs: {
-        classNames: 'page-text',
+        classNames: '',
         filePath: {
-          classNames: 'page-text',
+          classNames: '',
         },
         url: {
-          classNames: 'page-text',
+          classNames: 'input-width-limit',
         },
         clinicalSiteID: {
-          classNames: 'page-text',
+          classNames: 'input-width-limit',
         },
         clinicalSiteSystem: {
-          classNames: 'page-text',
+          classNames: 'input-width-limit',
         },
         type: {
-          classNames: 'page-text',
+          classNames: '',
         },
         mask: {
-          classNames: 'page-text',
+          classNames: '',
         },
       },
     },

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -176,3 +176,7 @@
   color: $secondary;
   font-weight: bold;
 }
+
+.input-width-limit {
+  max-width: 300px;
+}


### PR DESCRIPTION
### Summary
The initial task was to create a custom string input to be rendered by the react-jsonschema-form Form for string fields. However, this turned out to be unnecessary. The width issue was fixed with CSS classes instead.

### New Behavior
String fields are now limited to a max-width of 300px.

### Code Changes
- Added input-width-limit to Page.scss
- Modified CSS classes in uiSchema - added input-width-limit where appropriate
- Modified CSS classes in uiSchema - removed page-text from all fields, since it was only added for testing purposes in a previous task and is no longer necessary.
- Export statement in schemaFormUtils was once again fixed

### Testing Guidance
Start the app with npm start. Click on "Configuration Editor". Click on "Create New" or "Load". Many fields in the form will now have a maximum width of 300px. Fields that will be modified in other tasks (such as file inputs and fields in the extractor array) do not have a limited width.