### PR TITLE
Fixed getFile file types bug

### DIFF
--- a/electron/electron.js
+++ b/electron/electron.js
@@ -65,9 +65,9 @@ app.on('activate', () => {
 
 ipcMain.handle('get-config-schema', async () => configSchema);
 
-ipcMain.handle('get-file', async () =>
+ipcMain.handle('get-file', async (event, extensions) =>
   dialog.showOpenDialog(mainWindow, {
-    filters: [{ name: 'JSON', extensions: ['json'] }],
+    filters: [{ name: 'extensions', extensions }],
     properties: ['openFile'],
   }),
 );

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -7,7 +7,7 @@ contextBridge.exposeInMainWorld('api', {
   extract: async (fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) =>
     ipcRenderer.invoke('run-extraction', fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries),
   getConfigSchema: async () => ipcRenderer.invoke('get-config-schema'),
-  getFile: async () => ipcRenderer.invoke('get-file'),
+  getFile: async (extensions = []) => ipcRenderer.invoke('get-file', extensions),
   getOutputPath: async () => ipcRenderer.invoke('get-output-path'),
   readFile: async (filePath) => ipcRenderer.invoke('read-file', filePath),
   saveOutput: async (savePath, outputBundles, saveLogs) =>

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -35,7 +35,7 @@ function ConfigEditor() {
       setConfigSchema(schema);
     });
     window.api
-      .getFile()
+      .getFile(['json'])
       .then((result) => {
         if (result.filePaths[0] !== undefined) {
           return window.api.readFile(result.filePaths[0]);

--- a/react-app/src/components/Extract.js
+++ b/react-app/src/components/Extract.js
@@ -18,7 +18,7 @@ function Extract(props) {
   const history = useHistory();
 
   function setConfig() {
-    window.api.getFile().then((promise) => {
+    window.api.getFile(['json']).then((promise) => {
       // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
       if (promise.filePaths[0] !== undefined) {
         setConfigPath(promise.filePaths[0]);
@@ -31,7 +31,7 @@ function Extract(props) {
   }
 
   function setLog() {
-    window.api.getFile().then((promise) => {
+    window.api.getFile(['json']).then((promise) => {
       // after file is picked, call setConfigPath(file_name). This will both set the path and change the button text
       if (promise.filePaths[0] !== undefined) {
         setLogPath(promise.filePaths[0]);

--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -190,7 +190,7 @@ function FileWidget(props) {
     setPath('No File Selected');
   }
   function getFile() {
-    window.api.getFile().then((promise) => {
+    window.api.getFile(['csv']).then((promise) => {
       if (promise.filePaths[0] !== undefined) {
         setPath(promise.filePaths[0]);
         props.onChange(promise.filePaths[0]);


### PR DESCRIPTION
### Summary
The getFile process, which previously only allowed the user to select JSON files, now accepts an array of file extensions to determine which file types are allowed. The default is to allow any file type.

### New Behavior
None. The changes aren't visible in the front end.

### Code Changes
- window.api.getFile now has a parameter called 'extensions' with a default value of an empty array
- the get-file invoke and handler functions now receive and pass on the extensions array
- the handler uses the extensions array when passing options to the electron dialog
- calls to window.api.getFile have been modified to use the new parameter

### Testing Guidance
Use npm start to start the app. Go to the extraction and configuration processes and use the file pickers. They will only allow you to select the appropriate file type. At the moment, the only file picker that uses CSVs (as opposed to JSON files) is the patient MRNs picker on the configuration editor form.