### PR TITLE
Configuration Form is now saved to disk 

### DIFF
--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -24,13 +24,21 @@ function ConfigEditor() {
 
   function toggleForm() {
     getConfigSchema().then((schema) => {
+      // eslint-disable-next-line no-param-reassign
+      delete schema.description;
       setConfigSchema(schema);
     });
     setShowForm(!showForm);
   }
 
+  function closeForm() {
+    setShowForm(false);
+  }
+
   function loadFile() {
     getConfigSchema().then((schema) => {
+      // eslint-disable-next-line no-param-reassign
+      delete schema.description;
       setConfigSchema(schema);
     });
     window.api
@@ -81,7 +89,16 @@ function ConfigEditor() {
             )}
           </>
         )}
-        {showForm && <ConfigForm configJSON={configJSON} setShowForm={setShowForm} schema={configSchema} />}
+        {showForm && ( 
+          <>
+            <ConfigForm configJSON={configJSON} setShowForm={setShowForm} schema={configSchema} />
+            <div className="nav-button-container">
+              <Button className="generic-button" size="lg" variant="outline-secondary" onClick={closeForm}>
+                Back
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </>
   );

--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -9,18 +9,7 @@ function ConfigEditor() {
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [configSchema, setConfigSchema] = useState({});
-  const [configJSON, setConfigJSON] = useState({
-    $id: 'https://example.com/person.schema.json',
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    title: 'Person',
-    type: 'object',
-    properties: {
-      placeholder: {
-        type: 'string',
-        description: 'This is a placeholder for an actual config JSON',
-      },
-    },
-  });
+  const [configJSON, setConfigJSON] = useState({});
 
   function toggleForm() {
     getConfigSchema().then((schema) => {
@@ -91,7 +80,7 @@ function ConfigEditor() {
         )}
         {showForm && ( 
           <>
-            <ConfigForm configJSON={configJSON} setShowForm={setShowForm} schema={configSchema} />
+            <ConfigForm configJSON={configJSON} resetFormData={setConfigJSON} setShowForm={setShowForm} schema={configSchema} />
             <div className="nav-button-container">
               <Button className="generic-button" size="lg" variant="outline-secondary" onClick={closeForm}>
                 Back

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -35,15 +35,16 @@ function ConfigForm(props) {
     return formData;
   }
 
-  /* eslint-disable no-console */
-  function onSubmit(returnData) {
-    const configObj = cleanFormData(returnData.formData);
+  function onSubmit({formData}) {
+    const configObj = cleanFormData(formData);
     onSaveAs(configObj);
+    props.resetFormData(formData);
+
   }
 
   return (
     <>
-      <Form className="form-container" schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} onSubmit={onSubmit} noValidate={true}>
+      <Form className="form-container" schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} formData={props.configJSON} onSubmit={onSubmit} noValidate={true}>
         <Button className="generic-button" variant="outline-primary" type="submit">Save</Button>
       </Form>
       {showSavedAlert && (

--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -9,9 +9,9 @@ function ConfigForm(props) {
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
-  function onSaveAs() {
+  function onSaveAs(configJSON) {
     window.api
-      .saveConfigAs(props.configJSON)
+      .saveConfigAs(configJSON)
       .then((result) => {
         if (result !== null) {
           // if saveOutput() returns true, then the save process succeeded
@@ -26,13 +26,26 @@ function ConfigForm(props) {
         setShowSavedAlert(false);
       });
   }
-  function onBack() {
-    props.setShowForm(false);
+
+  function cleanFormData(formData){
+    formData.extractors.forEach(extractor => {
+      // eslint-disable-next-line no-param-reassign
+      delete extractor.id;
+    })
+    return formData;
+  }
+
+  /* eslint-disable no-console */
+  function onSubmit(returnData) {
+    const configObj = cleanFormData(returnData.formData);
+    onSaveAs(configObj);
   }
 
   return (
     <>
-      <Form className="form-container" schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} />
+      <Form className="form-container" schema={props.schema} uiSchema={uiSchema} widgets={widgets} fields={fields} onSubmit={onSubmit} noValidate={true}>
+        <Button className="generic-button" variant="outline-primary" type="submit">Save</Button>
+      </Form>
       {showSavedAlert && (
         <Alert variant="success" show={showSavedAlert} onClose={() => setShowSavedAlert(false)} dismissible>
           <Alert.Heading>Files saved</Alert.Heading>
@@ -44,16 +57,6 @@ function ConfigForm(props) {
           <Alert.Heading>Error: Unable to save file</Alert.Heading>
           <p>{errorMessage}</p>
         </Alert>
-      )}
-      {!showSavedAlert && !showErrorAlert && (
-        <div className="nav-button-container">
-          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onBack}>
-            Back
-          </Button>
-          <Button className="generic-button" size="lg" variant="outline-secondary" onClick={onSaveAs}>
-            Save As
-          </Button>
-        </div>
       )}
     </>
   );


### PR DESCRIPTION
This PR updates the 'Submit' button within the Configuration Editor to save the formData from the form component into a json file, rather than a placeholder object. 

I ended up using the Submit button that's provided as part of the `Form` component. This is because the only way to get the updated `formData` prop is by using the submit functionality built in to that component. I also moved the action bar containing the `Back` button from the `ConfigForm` to the `ConfigEditor` page because I felt that was a more intuitive location for it, but if others feel otherwise I can move it back.