### PR TITLE
Config Schema Updates to NotificationInfo.To

### DIFF
--- a/react-app/src/components/schemaFormUtils.js
+++ b/react-app/src/components/schemaFormUtils.js
@@ -16,6 +16,7 @@ const uiSchema = {
     classNames: '',
     baseFhirUrl: {
       classNames: 'input-width-limit',
+      'ui:placeholder': 'http://',
     },
     requestHeaders: {
       classNames: 'input-width-limit',


### PR DESCRIPTION
This is a companion PR to the config.schema.json changes made in [the MEF](https://github.com/mcode/mcode-extraction-framework/pull/157). The changes aren't apparent, since the MEF has yet to be updated, but this is where changes to the version of the MEF will live after local testing. 

To test, either [point the electron app's MEF dependency to your local version of the MEF,](https://stackoverflow.com/questions/14381898/local-dependency-in-package-json) or update the MEF branch to point at `#json-schema-notif-to-fix`. Once you've done that and rerun `npm install`, you should be able to see the changes to the notificationInfo.to property. The goal of testing should be to ensure that the titles associated with the config schema make it easier to understand where the To information should live. 

Once testing is done and a merge is complete on the MEF PR, we need to update our package-lock file. Then we should be good to merge. 