### PR TITLE
Create New initializes a new config json

### DIFF
--- a/react-app/src/components/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor.js
@@ -17,8 +17,8 @@ function ConfigEditor() {
       delete schema.description;
       setConfigSchema(schema);
       setConfigJSON({});
+      setShowForm(!showForm);
     });
-    setShowForm(!showForm);
   }
 
   function closeForm() {


### PR DESCRIPTION
Very simple fix – should address STEAM-764. 

Testing should ensure: 
- Create new always brings users to a fresh config-editor, regardless of any earlier config loading.
- This doesn't break any existing Create New Config-editor functionality.