### PR TITLE
Extractor js refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
   },
   rules: {
     'import/no-extraneous-dependencies': 'off',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
   },
 };

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -36,7 +36,18 @@
       "react-app/jest",
       "airbnb-base",
       "prettier"
-    ]
+    ],
+    "rules": {
+      "no-console": [
+        "error",
+        {
+          "allow": [
+            "warn",
+            "error"
+          ]
+        }
+      ]
+    }
   },
   "browserslist": {
     "production": [

--- a/react-app/src/components/Extractor.js
+++ b/react-app/src/components/Extractor.js
@@ -81,11 +81,12 @@ function defaultConstructorArgsMetadata(constructorArgs) {
 
 function Extractor(props) {
   // Get a label for the extractor
-  const extractorLabel = props.formData.label || '';
+  const [extractorLabel, setExtractorLabel] = useState(props.formData.label || '');
 
   // Update the extractorLabel as needed
   function onExtractorLabelChange(e) {
-    props.onExtractorLabelChange(e.target.value, props.eventKey);
+    props.onExtractorLabelChange(e.target.value);
+    setExtractorLabel(e.target.value);
   }
 
   // Derive and maintain some metadata about which constructorArgs can/should be rendered


### PR DESCRIPTION
Changes to make the Extractor.js file more readable, including: 
- extractorLabel is no longer local state, but instead is always derived from props.
- Renaming of locally-stored `constructorArgs` to `constructorArgsMetadata`, better capturing the essence of what local state in this file accomplishes (i.e. the state here controls the viewability of constructorArgs widgets, not the data within those widgets)
- Creating a function for generating the initial `constructorArgsMetadata` and hoisting it outside of the functional component.
- `getArgsJSX` function replaced with a filter/map over the `constructorArgsMetadata`, applying the `renderConstructorArg` function over all relevant constructorArgsMetadata elements.
- More frequent commenting above functions 
- `hasConstructorArgs` and `getConstructorOptions` are no longer functions, and are instead values derived from props/state.
- `constructorArgsMetadata[].included` changed to `constructorArgsMetadata[].hidden`, and all booleans/conditions are flipped accordingly. Included struck me as too vague (are they included in the file output data model? Included where?). Hidden felt more related to what purpose that value serves – deciding whether or not to render certain elements on the page. 

Review should: 
- Spot check my changes for sanity
- Read through the file for legibility/ease of understanding
- Ensure previous functionality is unaffected 