### PR TITLE
Error filtering in the configuration editor

### DIFF
--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 import Form from '@rjsf/bootstrap-4';
+import _ from 'lodash';
 import metaSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
 import { uiSchema, widgets, fields } from './schemaFormUtils';
 
@@ -36,6 +37,19 @@ function ConfigForm(props) {
     return formData;
   }
 
+  function transformErrors(errors) {
+    const filteredErrors = _.cloneDeep(errors);
+    const emailError = filteredErrors.find(error => error.name === 'format' && error.params.format  === 'comma-separated-emails');
+    if (emailError) {
+      emailError.message = 'Please include a list of comma separated email addresses';
+      const arrayErrorIndex = filteredErrors.findIndex(error => error.property === '.notificationInfo.to' && error.name === 'type');
+      filteredErrors.splice(arrayErrorIndex, 1);
+      const anyOfErrorIndex =  filteredErrors.findIndex(error => error.property === '.notificationInfo.to' && error.name === 'oneOf');
+      filteredErrors.splice(anyOfErrorIndex, 1);
+    }
+    return filteredErrors;
+  }
+
   function onSubmit({ formData }) {
     const configObj = cleanFormData(formData);
     onSaveAs(configObj);
@@ -53,6 +67,7 @@ function ConfigForm(props) {
         fields={fields}
         formData={props.configJSON}
         onSubmit={onSubmit}
+        transformErrors={transformErrors}
         // Validation information
         additionalMetaSchemas={[metaSchemaDraft06]}
         customFormats={{


### PR DESCRIPTION
Addresses some of the oddities we've encountered with the `comma-separated-emails` validation in the Configuration Editor. There were two separate issues going on here; the first being that two seemingly unrelated errors were being returned by the validator when validation for this field failed. That issue is addressed in this PR. The second issue is that validation errors for that field are rendered by RJSF twice, and [an issue for that has been filed on the RJSF repo](https://github.com/rjsf-team/react-jsonschema-form/issues/2584).

To test, start the Extraction UI and navigate to the Configuration Editor. Fill out the Notification Info section with the `comma separated emails` option for the To field and an invalid list of email addresses. Note that on master, the following errors should be included that are not rendered on this branch:
* `should be array`
* `should match exactly one schema in oneOf`