### PR TITLE
Adding dropdown picker for cancer type

### DIFF
--- a/react-app/src/components/ConfigForm.js
+++ b/react-app/src/components/ConfigForm.js
@@ -39,12 +39,18 @@ function ConfigForm(props) {
 
   function transformErrors(errors) {
     const filteredErrors = _.cloneDeep(errors);
-    const emailError = filteredErrors.find(error => error.name === 'format' && error.params.format  === 'comma-separated-emails');
+    const emailError = filteredErrors.find(
+      (error) => error.name === 'format' && error.params.format === 'comma-separated-emails',
+    );
     if (emailError) {
       emailError.message = 'Please include a list of comma separated email addresses';
-      const arrayErrorIndex = filteredErrors.findIndex(error => error.property === '.notificationInfo.to' && error.name === 'type');
+      const arrayErrorIndex = filteredErrors.findIndex(
+        (error) => error.property === '.notificationInfo.to' && error.name === 'type',
+      );
       filteredErrors.splice(arrayErrorIndex, 1);
-      const anyOfErrorIndex =  filteredErrors.findIndex(error => error.property === '.notificationInfo.to' && error.name === 'oneOf');
+      const anyOfErrorIndex = filteredErrors.findIndex(
+        (error) => error.property === '.notificationInfo.to' && error.name === 'oneOf',
+      );
       filteredErrors.splice(anyOfErrorIndex, 1);
     }
     return filteredErrors;

--- a/react-app/src/components/Extractor.js
+++ b/react-app/src/components/Extractor.js
@@ -48,8 +48,8 @@ function defaultConstructorArgsMetadata(constructorArgs) {
       type: 'dropdown',
       hidden: true,
       key: 'cancerType',
-      options: ['primary' ,'secondary', 'all'],
-      text: 'Select cancer types to include (if this argument is not included, \'all\' is chosen by default)',
+      options: ['primary', 'secondary', 'all'],
+      text: "Select cancer types to include (if this argument is not included, 'all' is chosen by default)",
       validExtractors: ['CSVCancerDiseaseStatusExtractor'],
     },
     {
@@ -299,11 +299,11 @@ function Extractor(props) {
                   const currentArg = getConstructorArg(newArgs, arg.key);
                   currentArg[arg.key] = e.target.value;
                   updateConstructorArgsMetadata(newArgs);
-                }}  
+                }}
                 className="arg-input-width-limit"
               >
                 {arg.options.map((option) => (
-                  <option value={option}>{option}</option>
+                  <option value={option} key={option}>{option}</option>
                 ))}
               </Form.Select>
               <Trash2


### PR DESCRIPTION
The cancer type constructor argument for Cancer Disease Status extractor in the config editor now has a dropdown picker limiting the choices to only the valid options. 