### PR TITLE
Adding option to start config editor from template

### DIFF
--- a/react-app/src/components/ConfigEditor/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor/ConfigEditor.js
@@ -134,7 +134,7 @@ function ConfigEditor() {
             {showErrorAlert && (
               <Alert variant="info" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
                 <Alert.Heading>Created config from template</Alert.Heading>
-                <p>Extractors have been added for you, but other fields will still need to be filled out</p>
+                <p>Extractors have been added for you, but CSV file paths / URLs and other fields will still need to be added</p>
               </Alert>
             )}
           </>

--- a/react-app/src/components/ConfigEditor/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor/ConfigEditor.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Button } from 'react-bootstrap';
+import { Alert, Button, Dropdown } from 'react-bootstrap';
 import _ from 'lodash';
 import EditorForm from './EditorForm';
 import { getConfigSchema } from './helpers/schemaFormUtils';
@@ -62,6 +62,37 @@ function ConfigEditor() {
       });
   }
 
+  function loadTemplate(filePath) {
+    getConfigSchema().then((schema) => {
+      // eslint-disable-next-line no-param-reassign
+      delete schema.description;
+      setConfigSchema(schema);
+    });
+    window.api.readFile(filePath)
+      .then((result) => {
+        if (result !== null) {
+          const config = JSON.parse(result);
+          // Add ids to the extractors
+          if (config.extractors) {
+            config.extractors = config.extractors.map((e) => ({ ...e, id: _.uniqueId() }));
+          }
+          setConfigJSON(config);
+          return true;
+        }
+        return null;
+      })
+      .then((result) => {
+        if (result) {
+          setShowForm(true);
+          setShowErrorAlert(true);
+        }
+      })
+      .catch((error) => {
+        setErrorMessage(error.message);
+        setShowErrorAlert(true);
+      });
+  }
+
   return (
     <>
       <h1 className="page-title">Configuration Editor</h1>
@@ -75,6 +106,13 @@ function ConfigEditor() {
               <Button className="vertical-menu-button" variant="outline-secondary" onClick={loadFile}>
                 Load File
               </Button>
+              <Dropdown className="vertical-menu-button" variant="outline-secondary">
+                <Dropdown.Toggle className="vertical-menu-button" variant="outline-secondary">Create From Template</Dropdown.Toggle>
+                <Dropdown.Menu>
+                  <Dropdown.Item onClick={() => loadTemplate('./react-app/src/components/ConfigEditor/templates/mcode.json')}>mCODE</Dropdown.Item>
+                  <Dropdown.Item onClick={() => loadTemplate('./react-app/src/components/ConfigEditor/templates/icare.json')}>ICARE</Dropdown.Item>
+                </Dropdown.Menu>
+              </Dropdown>
             </div>
             {showErrorAlert && (
               <Alert variant="danger" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
@@ -93,6 +131,12 @@ function ConfigEditor() {
               schema={configSchema}
               closeForm={closeForm}
             />
+            {showErrorAlert && (
+              <Alert variant="info" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
+                <Alert.Heading>Created config from template</Alert.Heading>
+                <p>Extractors have been added for you, but other fields will still need to be filled out</p>
+              </Alert>
+            )}
           </>
         )}
       </div>

--- a/react-app/src/components/ConfigEditor/templates/icare.json
+++ b/react-app/src/components/ConfigEditor/templates/icare.json
@@ -1,0 +1,24 @@
+{
+  "extractors": [
+    {
+      "label": "patient",
+      "type": "CSVPatientExtractor"
+    },
+    {
+      "label": "condition",
+      "type": "CSVConditionExtractor"
+    },
+    {
+      "label": "cancerDiseaseStatus",
+      "type": "CSVCancerDiseaseStatusExtractor"
+    },
+    {
+      "label": "clinicalTrialInformation",
+      "type": "CSVClinicalTrialInformationExtractor"
+    },
+    {
+      "label": "treatmentPlanChange",
+      "type": "CSVTreatmentPlanChangeExtractor"
+    }
+  ]
+}

--- a/react-app/src/components/ConfigEditor/templates/mcode.json
+++ b/react-app/src/components/ConfigEditor/templates/mcode.json
@@ -1,0 +1,48 @@
+{
+  "extractors": [
+    {
+      "label": "patient",
+      "type": "CSVPatientExtractor"
+    },
+    {
+      "label": "condition",
+      "type": "CSVConditionExtractor"
+    },
+    {
+      "label": "cancerDiseaseStatus",
+      "type": "CSVCancerDiseaseStatusExtractor"
+    },
+    {
+      "label": "clinicalTrialInformation",
+      "type": "CSVClinicalTrialInformationExtractor"
+    },
+    {
+      "label": "treatmentPlanChange",
+      "type": "CSVTreatmentPlanChangeExtractor"
+    },
+    {
+      "label": "staging",
+      "type": "CSVStagingExtractor"
+    },
+    {
+      "label": "cancerRelatedMedicationAdministration",
+      "type": "CSVCancerRelatedMedicationAdministrationExtractor"
+    },
+    {
+      "label": "cancerRelatedMedicationRequest",
+      "type": "CSVCancerRelatedMedicationRequestExtractor"
+    },
+    {
+      "label": "genericObservations",
+      "type": "CSVObservationExtractor"
+    },
+    {
+      "label": "genericProcedures",
+      "type": "CSVProcedureExtractor"
+    },
+    {
+      "label": "adverseEvent",
+      "type": "CSVAdverseEventExtractor"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a third option to the config editor page to "create from template" which will open the config editor with some fields already filled out. To start, I've added templates for "ICARE" which adds the extractors needed for ICARE and "mCODE" which adds all the extractors (or at least all the ones listed in the MEF's example config). To avoid possible confusion, there is also an alert that will tell the user that some fields have been filled out but others haven't.

To test:
- Go to the config editor
- Click "Create From Template" and pick an option
- See that the correct extractors were added and the config editor works as expected otherwise