### PR TITLE
Collapse Common Extractor Arguments and Notification Information sections

### DIFF
--- a/electron/helpers/configSchema.json
+++ b/electron/helpers/configSchema.json
@@ -8,6 +8,12 @@
       "title": "Patient ID CSV File",
       "type": "string"
     },
+    "commonExtractorArgs": {
+      "$ref": "#/$defs/commonExtractorArgs"
+    },
+    "notificationInfo": {
+      "$ref": "#/$defs/notificationInfo"
+    },
     "extractors": {
       "title": "Extractors",
       "type": "array",
@@ -28,7 +34,10 @@
         },
         "requestHeaders": {
           "title": "Request Headers",
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },
@@ -66,12 +75,14 @@
       "dependencies": {
         "host": {
           "required": [
+            "host",
             "to"
           ]
         },
         "to": {
           "required": [
-            "host"
+            "host",
+            "to"
           ]
         },
         "from": {

--- a/electron/helpers/configSchema.json
+++ b/electron/helpers/configSchema.json
@@ -8,12 +8,6 @@
       "title": "Patient ID CSV File",
       "type": "string"
     },
-    "commonExtractorArgs": {
-      "$ref": "#/$defs/commonExtractorArgs"
-    },
-    "notificationInfo": {
-      "$ref": "#/$defs/notificationInfo"
-    },
     "extractors": {
       "title": "Extractors",
       "type": "array",

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -8,7 +8,6 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
-        "@rjsf/bootstrap-4": "^3.1.0",
         "@rjsf/core": "^3.0.0",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^11.1.0",
@@ -2567,22 +2566,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@rjsf/bootstrap-4": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-3.1.0.tgz",
-      "integrity": "sha512-m3LutQx4912LkBBai8Y0gy3Lqgk/xTBjFJ6quX8JFCZjz57MJTVcix3u7LUC835k4EidDVG0GSmuqU0prnTlWQ==",
-      "dependencies": {
-        "react-icons": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@rjsf/core": "^3.0.0",
-        "react": ">=16",
-        "react-bootstrap": "^1.0.1"
       }
     },
     "node_modules/@rjsf/core": {
@@ -16159,25 +16142,6 @@
         "react": "^16.8.6 || ^17"
       }
     },
-    "node_modules/react-icons": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
-      "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
-      "dependencies": {
-        "camelcase": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/react-icons/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -24123,14 +24087,6 @@
             "dequal": "^2.0.2"
           }
         }
-      }
-    },
-    "@rjsf/bootstrap-4": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-3.1.0.tgz",
-      "integrity": "sha512-m3LutQx4912LkBBai8Y0gy3Lqgk/xTBjFJ6quX8JFCZjz57MJTVcix3u7LUC835k4EidDVG0GSmuqU0prnTlWQ==",
-      "requires": {
-        "react-icons": "^3.10.0"
       }
     },
     "@rjsf/core": {
@@ -34761,21 +34717,6 @@
       "integrity": "sha512-yMfCGRkZdXwIs23Zw/zIWCJO3m3tlaUvtHiXlW+3FH7cIT6fiK1iJ7RJWugXq7Fso8ZaQyUm92/GOOHXvkiVUw==",
       "requires": {
         "prop-types": "^15.7.2"
-      }
-    },
-    "react-icons": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
-      "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
-      "requires": {
-        "camelcase": "^5.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        }
       }
     },
     "react-is": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@rjsf/bootstrap-4": "^3.1.0",
     "@rjsf/core": "^3.0.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/react-app/src/components/ConfigEditor/CommonExtractorArgsAccordion.js
+++ b/react-app/src/components/ConfigEditor/CommonExtractorArgsAccordion.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Accordion, Row, Col } from 'react-bootstrap';
+
+function CommonExtractorArgs(props) {
+  const [baseFhirUrl, setBaseFhirUrl] = useState(props.formData?.baseFhirUrl || null);
+  const [requestHeaders, setRequestHeaders] = useState(props.formData?.requestHeaders || null);
+
+  const { SchemaField } = props.registry.fields;
+
+  return (
+    <div className="config-section-accordion">
+      {props.uiSchema['ui:label'] && <label>{props.uiSchema['ui:label']}</label>}
+      <Accordion>
+        <Accordion.Item eventKey="0">
+          <Accordion.Header>
+            <legend>Common Extractor Arguments</legend>
+          </Accordion.Header>
+          <Accordion.Body>
+            <Row>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setBaseFhirUrl(updatedVal);
+                    props.onChange({ requestHeaders, baseFhirUrl: updatedVal });
+                  }}
+                  formData={baseFhirUrl}
+                  schema={props.schema.properties.baseFhirUrl}
+                  uiSchema={props.uiSchema.baseFhirUrl}
+                  idSchema={props.idSchema.baseFhirUrl}
+                  required={props.schema.required?.some((r) => r === 'baseFhirUrl')}
+                  registry={props.registry}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setRequestHeaders(updatedVal);
+                    props.onChange({ baseFhirUrl, requestHeaders: updatedVal });
+                  }}
+                  formData={requestHeaders}
+                  schema={props.schema.properties.requestHeaders}
+                  uiSchema={props.uiSchema.requestHeaders}
+                  idSchema={props.idSchema.requestHeaders}
+                  required={props.schema.required?.some((r) => r === 'requestHeaders')}
+                  registry={props.registry}
+                />
+              </Col>
+            </Row>
+          </Accordion.Body>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  );
+}
+
+export default CommonExtractorArgs;

--- a/react-app/src/components/ConfigEditor/CommonExtractorArgsAccordion.js
+++ b/react-app/src/components/ConfigEditor/CommonExtractorArgsAccordion.js
@@ -27,6 +27,7 @@ function CommonExtractorArgs(props) {
                   schema={props.schema.properties.baseFhirUrl}
                   uiSchema={props.uiSchema.baseFhirUrl}
                   idSchema={props.idSchema.baseFhirUrl}
+                  errorSchema={props.errorSchema.baseFhirUrl}
                   required={props.schema.required?.some((r) => r === 'baseFhirUrl')}
                   registry={props.registry}
                 />
@@ -43,6 +44,7 @@ function CommonExtractorArgs(props) {
                   schema={props.schema.properties.requestHeaders}
                   uiSchema={props.uiSchema.requestHeaders}
                   idSchema={props.idSchema.requestHeaders}
+                  errorSchema={props.errorSchema.registry}
                   required={props.schema.required?.some((r) => r === 'requestHeaders')}
                   registry={props.registry}
                 />

--- a/react-app/src/components/ConfigEditor/EditorForm.js
+++ b/react-app/src/components/ConfigEditor/EditorForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
-import Form from '@rjsf/bootstrap-4';
+import Form from '@rjsf/core';
 import _ from 'lodash';
 import metaSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
 import { uiSchema, widgets, fields } from './helpers/schemaFormUtils';

--- a/react-app/src/components/ConfigEditor/ExtractorAccordion.js
+++ b/react-app/src/components/ConfigEditor/ExtractorAccordion.js
@@ -73,7 +73,7 @@ function ExtractorAccordion(props) {
 
   return (
     <div>
-      <h1 className="form-header-text">Extractors</h1>
+      <div className="form-header-text">Extractors</div>
       <div className="form-button-container">
         <Button
           variant="outline-info"

--- a/react-app/src/components/ConfigEditor/NotificationInfoAccordion.js
+++ b/react-app/src/components/ConfigEditor/NotificationInfoAccordion.js
@@ -30,6 +30,7 @@ function NotificationInfoAccordion(props) {
                   schema={props.schema.properties.host}
                   uiSchema={props.uiSchema.host}
                   idSchema={props.idSchema.host}
+                  errorSchema={props.errorSchema.host}
                   required={props.schema.required?.some((r) => r === 'host')}
                   registry={props.registry}
                 />
@@ -44,6 +45,7 @@ function NotificationInfoAccordion(props) {
                   schema={props.schema.properties.port}
                   uiSchema={props.uiSchema.port}
                   idSchema={props.idSchema.port}
+                  errorSchema={props.errorSchema.port}
                   required={props.schema.required?.some((r) => r === 'port')}
                   registry={props.registry}
                 />
@@ -60,6 +62,7 @@ function NotificationInfoAccordion(props) {
                   schema={props.schema.properties.to}
                   uiSchema={props.uiSchema.to}
                   idSchema={props.idSchema.to}
+                  errorSchema={props.errorSchema.to}
                   required={props.schema.required?.some((r) => r === 'to')}
                   registry={props.registry}
                 />
@@ -74,6 +77,7 @@ function NotificationInfoAccordion(props) {
                   schema={props.schema.properties.from}
                   uiSchema={props.uiSchema.from}
                   idSchema={props.idSchema.from}
+                  errorSchema={props.errorSchema.from}
                   required={props.schema.required?.some((r) => r === 'from')}
                   registry={props.registry}
                 />
@@ -89,6 +93,7 @@ function NotificationInfoAccordion(props) {
                 schema={props.schema.properties.tlsRejectUnauthorized}
                 uiSchema={props.uiSchema.tlsRejectUnauthorized}
                 idSchema={props.idSchema.tlsRejectUnauthorized}
+                errorSchema={props.errorSchema.tlsRejectUnauthorized}
                 required={props.schema.required?.some((r) => r === 'tlsRejectUnauthorized')}
                 registry={props.registry}
               />

--- a/react-app/src/components/ConfigEditor/NotificationInfoAccordion.js
+++ b/react-app/src/components/ConfigEditor/NotificationInfoAccordion.js
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Accordion, Row, Col } from 'react-bootstrap';
+
+function NotificationInfoAccordion(props) {
+  const [host, setHost] = useState(props.formData?.host || null);
+  const [port, setPort] = useState(props.formData?.port || null);
+  const [to, setTo] = useState(props.formData?.to || []);
+  const [from, setFrom] = useState(props.formData?.from || null);
+  const [tlsRejectUnauthorized, setTlsRejectUnauthorized] = useState(props.formData?.tlsRejectUnauthorized || false);
+
+  const { SchemaField } = props.registry.fields;
+
+  return (
+    <div className="config-section-accordion">
+      {props.uiSchema['ui:label'] && <label>{props.uiSchema['ui:label']}</label>}
+      <Accordion>
+        <Accordion.Item eventKey="0">
+          <Accordion.Header>
+            <legend>Notification Information</legend>
+          </Accordion.Header>
+          <Accordion.Body>
+            <Row>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setHost(updatedVal);
+                    props.onChange({ port, to, from, tlsRejectUnauthorized, host: updatedVal });
+                  }}
+                  formData={host}
+                  schema={props.schema.properties.host}
+                  uiSchema={props.uiSchema.host}
+                  idSchema={props.idSchema.host}
+                  required={props.schema.required?.some((r) => r === 'host')}
+                  registry={props.registry}
+                />
+              </Col>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setPort(updatedVal);
+                    props.onChange({ host, to, from, tlsRejectUnauthorized, port: updatedVal });
+                  }}
+                  formData={port}
+                  schema={props.schema.properties.port}
+                  uiSchema={props.uiSchema.port}
+                  idSchema={props.idSchema.port}
+                  required={props.schema.required?.some((r) => r === 'port')}
+                  registry={props.registry}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setTo(updatedVal);
+                    props.onChange({ host, port, from, tlsRejectUnauthorized, to: updatedVal });
+                  }}
+                  formData={to}
+                  schema={props.schema.properties.to}
+                  uiSchema={props.uiSchema.to}
+                  idSchema={props.idSchema.to}
+                  required={props.schema.required?.some((r) => r === 'to')}
+                  registry={props.registry}
+                />
+              </Col>
+              <Col>
+                <SchemaField
+                  onChange={(updatedVal) => {
+                    setFrom(updatedVal);
+                    props.onChange({ host, port, to, tlsRejectUnauthorized, from: updatedVal });
+                  }}
+                  formData={from}
+                  schema={props.schema.properties.from}
+                  uiSchema={props.uiSchema.from}
+                  idSchema={props.idSchema.from}
+                  required={props.schema.required?.some((r) => r === 'from')}
+                  registry={props.registry}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <SchemaField
+                onChange={(updatedVal) => {
+                  setTlsRejectUnauthorized(updatedVal);
+                  props.onChange({ host, port, to, from, tlsRejectUnauthorized: updatedVal });
+                }}
+                formData={tlsRejectUnauthorized}
+                schema={props.schema.properties.tlsRejectUnauthorized}
+                uiSchema={props.uiSchema.tlsRejectUnauthorized}
+                idSchema={props.idSchema.tlsRejectUnauthorized}
+                required={props.schema.required?.some((r) => r === 'tlsRejectUnauthorized')}
+                registry={props.registry}
+              />
+            </Row>
+          </Accordion.Body>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  );
+}
+
+export default NotificationInfoAccordion;

--- a/react-app/src/components/ConfigEditor/helpers/schemaFormUtils.js
+++ b/react-app/src/components/ConfigEditor/helpers/schemaFormUtils.js
@@ -1,40 +1,40 @@
 import React, { useState } from 'react';
 import FilePicker from '../../CommonComponents/FilePicker';
 import ExtractorAccordion from '../ExtractorAccordion';
+import NotificationInfoAccordion from '../NotificationInfoAccordion';
+import CommonExtractorArgsAccordion from '../CommonExtractorArgsAccordion';
 
 function getConfigSchema() {
   return window.api.getConfigSchema();
 }
 
 const uiSchema = {
+  'ui:order': ['patientIdCsvPath', 'extractors', '*'],
   patientIdCsvPath: {
     'ui:label': false,
     'ui:widget': 'file',
     classNames: 'form-label-header-text',
   },
   commonExtractorArgs: {
-    classNames: '',
+    'ui:field': 'commonExtractorArgs',
+    'ui:label': 'Optional Configuration Fields',
+    classNames: 'form-label-header-text',
     baseFhirUrl: {
       classNames: 'input-width-limit',
       'ui:placeholder': 'http://',
     },
     requestHeaders: {
-      classNames: 'input-width-limit',
+      classNames: 'additional-properties-width input-array-label',
     },
   },
   notificationInfo: {
+    'ui:field': 'notificationInfoAccordion',
     classNames: '',
-    host: {
-      classNames: 'input-width-limit',
-    },
-    port: {
-      classNames: 'input-width-limit',
-    },
-    from: {
-      classNames: 'input-width-limit',
-    },
+    host: {},
+    port: {},
+    from: {},
     to: {
-      classNames: 'input-width-limit',
+      classNames: 'input-array-label',
     },
     tlsRejectUnauthorized: {
       classNames: '',
@@ -119,6 +119,8 @@ const widgets = {
 
 const fields = {
   extractorArray: ExtractorAccordion,
+  notificationInfoAccordion: NotificationInfoAccordion,
+  commonExtractorArgs: CommonExtractorArgsAccordion,
 };
 
 export { getConfigSchema, uiSchema, widgets, fields };

--- a/react-app/src/components/ConfigEditor/helpers/schemaFormUtils.js
+++ b/react-app/src/components/ConfigEditor/helpers/schemaFormUtils.js
@@ -10,7 +10,7 @@ const uiSchema = {
   patientIdCsvPath: {
     'ui:label': false,
     'ui:widget': 'file',
-    classNames: '',
+    classNames: 'form-label-header-text',
   },
   commonExtractorArgs: {
     classNames: '',

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -129,6 +129,23 @@ i.glyphicon {
   font-weight: bold;
 }
 
+.additional-properties-width > fieldset > div.form-group > div.row {
+  // RJSF uses react-bootstrap-3 classnames, so apply the current bootstrap-5 styling to the old class names
+  .col-xs-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+
+  .col-xs-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+}
+
+.config-section-accordion {
+  margin-bottom: 10px;
+}
+
 .text-centered {
   text-align: center;
 }
@@ -218,6 +235,10 @@ i.glyphicon {
   color: $secondary;
   font-weight: bold;
   text-align: right;
+}
+
+.input-array-label > fieldset > legend {
+  font-size: 1rem;
 }
 
 .input-width-limit {

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -267,3 +267,26 @@ i.glyphicon {
 .navbar-brand {
   font-family: 'Courier New', 'Monaco', monospace;
 }
+
+.has-danger {
+  // RJSF uses react-bootstrap-3 classnames, so apply the current bootstrap-5 styling to the old class names
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-danger-rgb), var(--bs-text-opacity)) !important;
+}
+
+div.field-error > .form-control {
+  // RJSF Form with bootstrap-4 styling adds these properties, so want to mimic when we use the core Form
+  border-color: #f44336;
+  padding-right: calc(1.5em + 0.75rem);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23f44336'%3E%3Ccircle cx='6' cy='6' r='4.5'/%3E%3Cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3E%3Ccircle cx='6' cy='8.2' r='.6' fill='%23f44336' stroke='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right calc(0.375em + 0.1875rem) center;
+  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+
+div.field-error > div > ul {
+  // RJSF Form with bootstrap-4 styling adds these properties, so want to mimic when we use the core Form
+  padding: 0;
+  list-style-type: none;
+  font-size: 14px;
+}

--- a/react-app/src/stylesheets/Page.scss
+++ b/react-app/src/stylesheets/Page.scss
@@ -110,6 +110,12 @@ i.glyphicon {
   font-weight: bold;
 }
 
+.form-label-header-text > div > label {
+  font-size: 30px;
+  margin-bottom: 10px;
+  margin-top: 20px;
+}
+
 .form-header-text {
   font-size: 30px;
   margin-bottom: 10px;


### PR DESCRIPTION
This PR focuses on collapsing the Common Extractor Arguments and Notification Information sections in the configuration editor. This lets the focus remain on the more important (and required) Patient Id and Extractor sections. To do this, this PR makes a few key changes:
- Specified an order to the sections that are displayed so the Patient Id CSV File and Extractors come first
- Adds custom components for Common Extractor Arguments and Notification Information. These components wrap the fields in an accordion and then use RJSF's `SchemaField` to render the individiual fields. This was the best middle ground I could find for allowing us to control the surrounding rendering (the accordion) while still utilizing all the functionality RJSF provides for the individual fields (like the input boxes and the component for the To field).
- Reverts back to using the core RJSF `Form` component in order to get the ability to add arbitrary key/value pairs for Request Headers. This functionality doesn't work properly in the bootstrap-4 Form (as evidenced in the [additional properties demo](https://rjsf-team.github.io/react-jsonschema-form/) and documented in this [issue](https://github.com/rjsf-team/react-jsonschema-form/issues/1927)).
  - Reverting back tot he core RJSF `Form` also seems to allow the `classNames` we provide in the uiSchema to work again
  - However, some of the bootstrap-3 classes that the form now uses don't match the ones that our current bootstrap version uses, so I updated a few CSS classes to do their best to mimic the targeted styling in the old class name.
- A few minor changes to the `configSchema`
  - Added the ability to add arbitrary key/value pairs so the UI could allow adding these values
  - Added the "host" and "to" dependencies because the `*` that indicates required was missing on the "To" field when there was "Host" data and vice versa.
 
I removed the `@rjsf/bootstrap-4` since I decided not to use it, but if any of the above changes don't feel that they're worth the styling changes they cause, I can revert and add it back.

This should still work with loading in an existing file, loading a template, and saving a file. No functionality should be lost.