### PR TITLE
Adding start script to check for OS and call appropriate commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "prettier": "prettier --check \"**/*.js\"",
     "prettier:fix": "prettier --write \"**/*.js\"",
     "publish": "electron-forge publish",
-    "start": "npm-run-all -p start:frontend start:electron",
+    "start": "node ./start.js",
+    "start:windows": "npm-run-all -p start:frontend:windows start:electron",
+    "start:nonwindows": "npm-run-all -p start:frontend start:electron",
     "start:electron": "wait-on tcp:3000 && electron-forge start",
-    "start:frontend": "cd ./react-app && BROWSER=none npm start"
+    "start:frontend": "cd ./react-app && BROWSER=none npm start",
+    "start:frontend:windows": "cd ./react-app && set BROWSER=none && npm run start:windows"
   },
   "keywords": [],
   "contributors": [

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "start": "ESLINT_NO_DEV_ERRORS=true react-scripts start",
+    "start:windows": "set ESLINT_NO_DEV_ERRORS=true && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/start.js
+++ b/start.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+if (process.platform === 'win32') {
+  spawn('npm.cmd', ['run', 'start:windows'], { stdio: 'inherit' });
+} else {
+  spawn('npm', ['run', 'start:nonwindows'], { stdio: 'inherit' });
+}


### PR DESCRIPTION
This PR adds a new script, `start.js`, that is called by `npm start` and checks for operating system, then calls the appropriate commands to start the app on that OS. The app should run exactly the same as before on Linux/Mac, but will now run properly in Windows when called with `npm start`