### PR TITLE
Disallowing relative filepaths in loaded config files

### DIFF
--- a/electron/extraction.js
+++ b/electron/extraction.js
@@ -1,3 +1,4 @@
+const { isAbsolute } = require('path');
 const { getConfig, logger, mcodeApp, MCODEClient } = require('mcode-extraction-framework');
 
 async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries) {
@@ -15,6 +16,18 @@ async function runExtraction(fromDate, toDate, configFilepath, runLogFilepath, d
       defaultDebug = undefined;
     }
     const config = getConfig(configFilepath);
+    if ('patientIdCsvPath' in config && !isAbsolute(config.patientIdCsvPath)) {
+      throw new Error("Patient ID CSV path must not be a relative path.");
+    }
+    if ('extractors' in config) {
+      config.extractors.forEach((extractor) => {
+        if ('constructorArgs' in extractor && 'filePath' in extractor.constructorArgs) {
+          if (!isAbsolute(extractor.constructorArgs.filePath)) {
+            throw new Error("Extractor file paths must not be relative paths.");
+          }
+        }
+      })
+    }
     const extractedData = await mcodeApp(
       MCODEClient,
       defaultFromDate,


### PR DESCRIPTION
This PR adds a check for relative paths after the config file is loaded and before extraction starts, if there are relative paths in the patientIdCsvPath or any extractor filePath fields, an error will occur telling the user that they cannot use relative paths for these fields. To test: load a config file with a relative path in any extractor object or in the patientIdCsvPath field and you should see an error upon submitting.

I did consider various ways to immediately link the user to the config editor to fix this but then remembered that we had STEAM-716 (Design linking the configuration file editing with the Extract New page) in the backlog, so I went with a simpler solution for now, and I'll just note here that converting a relative path config file to an absolute path config file would be a situation where linking the Extract New page and config editor would be very useful. 