### PR TITLE
Changing to modals to avoid resetting on closing alert

### DIFF
--- a/react-app/src/components/ConfigEditor/ConfigEditor.js
+++ b/react-app/src/components/ConfigEditor/ConfigEditor.js
@@ -12,6 +12,7 @@ function ConfigEditor() {
   const [errorMessage, setErrorMessage] = useState('');
   const [configSchema, setConfigSchema] = useState({});
   const [configJSON, setConfigJSON] = useState({});
+  const [templateAlert, setTemplateAlert] = useState(false);
 
   function toggleForm() {
     getConfigSchema().then((schema) => {
@@ -112,8 +113,8 @@ function ConfigEditor() {
           template.extractors = template.extractors.map((e) => ({ ...e, id: _.uniqueId() }));
         }
         setConfigJSON(template);
+        setTemplateAlert(true);
         setShowForm(true);
-        setShowErrorAlert(true);
       });
   }
 
@@ -156,16 +157,8 @@ function ConfigEditor() {
               setShowForm={setShowForm}
               schema={configSchema}
               closeForm={closeForm}
+              templateAlert={templateAlert}
             />
-            {showErrorAlert && (
-              <Alert variant="info" show={showErrorAlert} onClose={() => setShowErrorAlert(false)} dismissible>
-                <Alert.Heading>Created config from template</Alert.Heading>
-                <p>
-                  Extractors have been added for you, but CSV file paths / URLs and other fields will still need to be
-                  added
-                </p>
-              </Alert>
-            )}
           </>
         )}
       </div>

--- a/react-app/src/components/ConfigEditor/EditorForm.js
+++ b/react-app/src/components/ConfigEditor/EditorForm.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Button } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
 import Form from '@rjsf/core';
 import _ from 'lodash';
 import metaSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
@@ -10,6 +10,7 @@ function EditorForm(props) {
   const [savedMessage, setSavedMessage] = useState('');
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [showTemplateAlert, setShowTemplateAlert] = useState(props.templateAlert);
 
   function onSaveAs(configJSON) {
     window.api
@@ -99,28 +100,24 @@ function EditorForm(props) {
           </Button>
         </div>
       </Form>
-      <Alert
-        className="nav-button-alert"
-        variant="success"
-        show={showSavedAlert}
-        onClose={() => setShowSavedAlert(false)}
-        dismissible
-        transition
-      >
-        <Alert.Heading>Files saved</Alert.Heading>
-        <p>{savedMessage}</p>
-      </Alert>
-      <Alert
-        className="nav-button-alert"
-        variant="danger"
-        show={showErrorAlert}
-        onClose={() => setShowErrorAlert(false)}
-        dismissible
-        transition
-      >
-        <Alert.Heading>Error: Unable to save file</Alert.Heading>
-        <p>{errorMessage}</p>
-      </Alert>
+      <Modal show={showSavedAlert} onHide={() => setShowSavedAlert(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Files saved</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{savedMessage}</Modal.Body>
+      </Modal>
+      <Modal show={showErrorAlert} onHide={() => setShowErrorAlert(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Error: Unable to save file</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{errorMessage}</Modal.Body>
+      </Modal>
+      <Modal show={showTemplateAlert} onHide={() => setShowTemplateAlert(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Created config from template</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Extractors have been added for you, but CSV file paths / URLs and other fields will still need to be added</Modal.Body>
+      </Modal>
     </>
   );
 }


### PR DESCRIPTION
There is an error where closing an alert after modifying extractors in the config editor resets the extractors to what they were when the alert happened. I couldn't really figure out why this happens (probably has something to do with the extractors being custom ui object, since nothing happens to standard fields like text fields) so I switched the alerts to modals that automatically close when you click somewhere else on the screen, meaning users can't make any changes before closing the message, thus side stepping the error.

You can test the changes by loading from a template, saving a config file, or getting an error while saving the config file. There are still other Alerts in the UI, but in places that didn't have this bug so I left those as is. I also didn't mess with the styling of the modals at all, but I think they look pretty good in the default state, open to suggestions.